### PR TITLE
NEW: 캔버스 생성하기 및 줌인 기능 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "no-unused-vars": "warn",
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/no-static-element-interactions": 0,
-    "jsx-a11y/no-noninteractive-element-interactions": 0
+    "jsx-a11y/no-noninteractive-element-interactions": 0,
+    "jsx-a11y/no-autofocus": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack-dev-server",
-    "build": "webpack --mode production --progress",
+    "build": "NODE_ENV=production webpack --mode production --progress",
     "prepare": "husky install"
   },
   "author": "intaek h",

--- a/src/components/atoms/ArtBoard/index.js
+++ b/src/components/atoms/ArtBoard/index.js
@@ -1,37 +1,137 @@
-import { useEffect, useRef } from "react";
-import { useSelector } from "react-redux";
+import { useEffect, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import styles from "./ArtBoard.module.scss";
 import useDragScroll from "../../../hooks/useDragScroll";
-import { selectAllCanvas } from "../../../features/canvas/canvasSlice";
-import Shape from "../Shape";
+import {
+  createCanvas,
+  selectAllCanvas,
+} from "../../../features/canvas/canvasSlice";
+import Canvas from "../Canvas";
 import useMockZoom from "../../../hooks/useMockZoom";
+import computePreviewElement from "../../../utilities/computePreviewElement";
+import { selectCurrentScale } from "../../../features/utility/utilitySlice";
+
+let isFirstRender = true;
 
 function ArtBoard() {
+  const dispatch = useDispatch();
+  const currentScale = useSelector(selectCurrentScale);
+
   const boardRef = useRef();
   const innerBoardRef = useRef();
 
+  const [isDragScrolling, setIsDragScrolling] = useState(false);
+
   const canvases = useSelector(selectAllCanvas);
 
-  useDragScroll(boardRef);
+  useDragScroll(boardRef, setIsDragScrolling);
 
   useMockZoom(boardRef, innerBoardRef);
 
   useEffect(() => {
-    if (!boardRef.current) return;
+    if (!boardRef.current || !isFirstRender) return;
 
     const { top, left, width } = canvases[canvases.length - 1];
 
+    isFirstRender = false;
     boardRef.current.scrollTop = top - 100;
     boardRef.current.scrollLeft =
       left - boardRef.current.clientWidth / 2 + width / 2;
   }, [canvases]);
 
+  useEffect(() => {
+    if (!innerBoardRef.current) return;
+
+    const innerBoard = innerBoardRef.current;
+
+    const handleMouseDownCanvas = (e) => {
+      if (isDragScrolling) return;
+
+      const canvasPreview = document.createElement("div");
+      const artboardNode = innerBoard.getBoundingClientRect();
+      const artboardTop = artboardNode.top;
+      const artboardLeft = artboardNode.left;
+      const startTop = (e.clientY - artboardTop) / currentScale;
+      const startLeft = (e.clientX - artboardLeft) / currentScale;
+
+      canvasPreview.style.top = startTop + "px";
+      canvasPreview.style.left = startLeft + "px";
+      canvasPreview.style.backgroundColor = "#4faaff36";
+      canvasPreview.style.border = "1px solid #94beff";
+      canvasPreview.style.position = "absolute";
+      canvasPreview.style.boxSizing = "border-box";
+
+      const sizePreview = document.createElement("div");
+
+      innerBoard.appendChild(canvasPreview);
+      innerBoard.appendChild(sizePreview);
+
+      const handleMouseMove = (e) => {
+        const { height, left, top, width } = computePreviewElement(
+          { x: startLeft, y: startTop },
+          {
+            x: (e.clientX - artboardLeft) / currentScale,
+            y: (e.clientY - artboardTop) / currentScale,
+          }
+        );
+
+        canvasPreview.style.height = height + "px";
+        canvasPreview.style.width = width + "px";
+        canvasPreview.style.top = top + "px";
+        canvasPreview.style.left = left + "px";
+
+        sizePreview.textContent = `${width} X ${height}`;
+        sizePreview.style.position = "absolute";
+        sizePreview.style.top = top + height + 10 + "px";
+        sizePreview.style.left = left + width + 10 + "px";
+        sizePreview.style.backgroundColor = "black";
+        sizePreview.style.color = "white";
+        sizePreview.style.fontSize = "10px";
+        sizePreview.style.opacity = 0.3;
+        sizePreview.style.padding = "0 2px";
+      };
+
+      const handleMouseUp = (e) => {
+        if (e.button === 2) {
+          canvasPreview.remove();
+          sizePreview.remove();
+          innerBoard.removeEventListener("mousemove", handleMouseMove);
+          innerBoard.removeEventListener("mouseup", handleMouseUp);
+          return;
+        }
+
+        const coordinates = {
+          top: canvasPreview.offsetTop,
+          left: canvasPreview.offsetLeft,
+          height: canvasPreview.offsetHeight,
+          width: canvasPreview.offsetWidth,
+        };
+
+        coordinates.height + coordinates.width > 4 &&
+          dispatch(createCanvas(coordinates));
+
+        canvasPreview.remove();
+        sizePreview.remove();
+        innerBoard.removeEventListener("mousemove", handleMouseMove);
+        innerBoard.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      innerBoard.addEventListener("mousemove", handleMouseMove);
+      innerBoard.addEventListener("mouseup", handleMouseUp);
+    };
+
+    innerBoard.addEventListener("mousedown", handleMouseDownCanvas);
+
+    return () =>
+      innerBoard.removeEventListener("mousedown", handleMouseDownCanvas);
+  }, [currentScale, dispatch, isDragScrolling]);
+
   return (
     <div ref={boardRef} className={styles["artboard-wrapper"]}>
       <div ref={innerBoardRef} className={styles.artboard}>
         {canvases.map((canvas, i) => (
-          <Shape {...canvas} key={i} />
+          <Canvas {...canvas} index={i} key={i} />
         ))}
       </div>
     </div>

--- a/src/components/atoms/Canvas/Canvas.module.scss
+++ b/src/components/atoms/Canvas/Canvas.module.scss
@@ -1,0 +1,22 @@
+@use "../../scss/forwards" as *;
+
+.name {
+  font-size: $regular-font-size;
+  color: $text-canvas-title;
+  position: absolute;
+  transform: translateY(-100%);
+  user-select: none;
+}
+
+.input {
+  font-family: "Inter", sans-serif;
+  font-size: $regular-font-size;
+  color: $text-highlight;
+  position: absolute;
+  transform: translateY(-100%);
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+  border: none;
+  outline: none;
+}

--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -1,0 +1,53 @@
+import { useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+
+import { changeCanvasName } from "../../../features/canvas/canvasSlice";
+import cn from "./Canvas.module.scss";
+
+function Canvas({ index, ...canvas }) {
+  const dispatch = useDispatch();
+
+  const inputRef = useRef();
+
+  const [isDoubleClicked, setIsDoubleClicked] = useState(false);
+
+  return (
+    <>
+      {isDoubleClicked ? (
+        <input
+          ref={inputRef}
+          type="text"
+          className={cn.input}
+          style={{
+            top: canvas.top,
+            left: canvas.left,
+          }}
+          defaultValue={canvas.canvasName}
+          autoFocus
+          onBlur={() => {
+            setIsDoubleClicked(false);
+            dispatch(changeCanvasName({ name: inputRef.current.value, index }));
+          }}
+        />
+      ) : (
+        <span
+          className={cn.name}
+          style={{
+            top: canvas.top,
+            left: canvas.left,
+          }}
+          onDoubleClick={() => {
+            setIsDoubleClicked(true);
+          }}
+        >
+          {canvas.canvasName}
+        </span>
+      )}
+      <div
+        style={{ ...canvas, position: "absolute", backgroundColor: "white" }}
+      ></div>
+    </>
+  );
+}
+
+export default Canvas;

--- a/src/components/atoms/HighlightedText/index.js
+++ b/src/components/atoms/HighlightedText/index.js
@@ -1,7 +1,15 @@
+import { useDispatch } from "react-redux";
+import { createCanvas } from "../../../features/canvas/canvasSlice";
 import styles from "./HighlightedText.module.scss";
 
 function HighlightedText({ text }) {
-  return <span className={styles.text}>{text}</span>;
+  const dispatch = useDispatch();
+
+  return (
+    <span className={styles.text} onClick={() => dispatch(createCanvas({}))}>
+      {text}
+    </span>
+  );
 }
 
 export default HighlightedText;

--- a/src/components/atoms/Shape/index.js
+++ b/src/components/atoms/Shape/index.js
@@ -1,9 +1,0 @@
-function Shape({ ...styles }) {
-  return (
-    <div
-      style={{ ...styles, position: "absolute", backgroundColor: "white" }}
-    />
-  );
-}
-
-export default Shape;

--- a/src/components/scss/_colors.scss
+++ b/src/components/scss/_colors.scss
@@ -3,6 +3,7 @@ $text-white: #fff;
 $text-highlight: #5096ff;
 $text-warning: #ff5050;
 $text-guide: #999999;
+$text-canvas-title: #d9d9d9;
 
 $object-header-bg: #272727;
 $object-sidebar-bg: #fff;

--- a/src/components/scss/_variables.scss
+++ b/src/components/scss/_variables.scss
@@ -1,2 +1,2 @@
-$artboard-width: 4800px;
-$artboard-height: 4800px;
+$artboard-width: 48000px;
+$artboard-height: 48000px;

--- a/src/features/canvas/canvasSlice.js
+++ b/src/features/canvas/canvasSlice.js
@@ -1,9 +1,14 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-const generateSampleCanvas = (width = 390, height = 800) => ({
+const generateSampleCanvas = (
+  top = 1000,
+  left = 1000,
+  width = 390,
+  height = 800
+) => ({
   canvasName: "canvas_0",
-  top: 1000,
-  left: 1000,
+  top,
+  left,
   width,
   height,
   xAxisSnap: [0, width / 2, width],
@@ -18,22 +23,22 @@ const canvasSlice = createSlice({
   name: "canvas",
   initialState,
   reducers: {
-    createCanvas: (state, { payload: { width, height } }) => {
-      const lastCanvas = state[state.length - 1];
+    createCanvas: (state, { payload: { top, left, width, height } }) => {
       const newCanvas = {
-        ...generateSampleCanvas(width, height),
-        top: lastCanvas.top,
-        left: lastCanvas.left + lastCanvas.width + 30,
+        ...generateSampleCanvas(top, left, width, height),
         canvasName: `canvas_${state.length}`,
       };
 
       state.push(newCanvas);
+    },
+    changeCanvasName: (state, { payload: { name, index } }) => {
+      state[index].canvasName = name;
     },
   },
 });
 
 export const selectAllCanvas = (state) => state.workbench.present.canvas;
 
-export const { createCanvas } = canvasSlice.actions;
+export const { createCanvas, changeCanvasName } = canvasSlice.actions;
 
 export default canvasSlice.reducer;

--- a/src/hooks/useDragScroll.js
+++ b/src/hooks/useDragScroll.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-function useDragScroll(boardRef) {
+function useDragScroll(boardRef, setIsDragScrolling) {
   useEffect(() => {
     if (!boardRef.current) return;
 
@@ -38,6 +38,7 @@ function useDragScroll(boardRef) {
     const handleSpaceKeyDown = (e) => {
       if (e.keyCode === 32) {
         e.preventDefault();
+        setIsDragScrolling(true);
         board.style.cursor = "grab";
         board.addEventListener("mousedown", handleMouseDown);
         document.addEventListener("keyup", handleSpaceKeyUp);
@@ -47,16 +48,17 @@ function useDragScroll(boardRef) {
     const handleSpaceKeyUp = (e) => {
       if (e.keyCode === 32) {
         e.preventDefault();
+        setIsDragScrolling(false);
         board.style.cursor = "default";
-        document.removeEventListener("keyup", handleSpaceKeyUp);
         board.removeEventListener("mousedown", handleMouseDown);
+        document.removeEventListener("keyup", handleSpaceKeyUp);
       }
     };
 
     document.addEventListener("keydown", handleSpaceKeyDown);
 
     return () => document.removeEventListener("keydown", handleSpaceKeyDown);
-  }, [boardRef]);
+  }, [boardRef, setIsDragScrolling]);
 }
 
 export default useDragScroll;

--- a/src/hooks/useMockZoom.js
+++ b/src/hooks/useMockZoom.js
@@ -5,7 +5,7 @@ import {
   selectCurrentScale,
   setCurrentScale,
 } from "../features/utility/utilitySlice";
-import { customizeZoom } from "../utilities/helpers";
+import { calculateMockZoom } from "../utilities/calculateMockZoom";
 
 function useMockZoom(outerRef, innerRef) {
   const currentScale = useSelector(selectCurrentScale);
@@ -30,7 +30,7 @@ function useMockZoom(outerRef, innerRef) {
       ) {
         event.preventDefault();
 
-        const { adjustedScroll, scale } = customizeZoom(
+        const { adjustedScroll, scale } = calculateMockZoom(
           outerBoard,
           event,
           currentScale
@@ -47,7 +47,7 @@ function useMockZoom(outerRef, innerRef) {
       if (event.ctrlKey || event.metaKey) {
         event.preventDefault();
 
-        const { adjustedScroll, scale } = customizeZoom(
+        const { adjustedScroll, scale } = calculateMockZoom(
           outerBoard,
           event,
           currentScale

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { Provider } from "react-redux";
 
 import App from "./App";
 import store from "./store/configureStore";
+import "./utilities/defaultEventListeners";
 
 const root = document.querySelector("#root");
 

--- a/src/utilities/calculateMockZoom.js
+++ b/src/utilities/calculateMockZoom.js
@@ -1,4 +1,8 @@
-export const customizeZoom = (element, event, prevScale) => {
+const SCALE_FACTOR = 0.1;
+const MAX_SCALE = 4;
+const MINIMUM_ZOOM_OUT = 0.9;
+
+export const calculateMockZoom = (element, event, prevScale) => {
   if (typeof event.wheelDelta !== "number") {
     if (event.which === 107 || event.which === 61 || event.which === 187) {
       event.wheelDelta = 1;
@@ -8,9 +12,6 @@ export const customizeZoom = (element, event, prevScale) => {
     event.pageX = element.offsetParent.offsetWidth / 2;
     event.pageY = element.offsetParent.offsetHeight / 2;
   }
-
-  const SCALE_FACTOR = 0.1;
-  const MAX_SCALE = 4;
   const scrollDirection = Math.sign(event.wheelDelta);
 
   const innerBoardPositionFromOuterBoard = {
@@ -32,7 +33,7 @@ export const customizeZoom = (element, event, prevScale) => {
   let scale;
 
   if (requestedScale < 1) {
-    scale = Math.max(0.9, Math.min(MAX_SCALE, requestedScale));
+    scale = Math.max(MINIMUM_ZOOM_OUT, requestedScale);
   } else {
     scale = Math.max(1, Math.min(MAX_SCALE, requestedScale));
   }

--- a/src/utilities/computePreviewElement.js
+++ b/src/utilities/computePreviewElement.js
@@ -1,0 +1,10 @@
+const computePreviewElement = (startPoint, endPoint) => {
+  const left = Math.min(startPoint.x, endPoint.x);
+  const top = Math.min(startPoint.y, endPoint.y);
+  const width = Math.abs(startPoint.x - endPoint.x);
+  const height = Math.abs(startPoint.y - endPoint.y);
+
+  return { top, left, height: Math.floor(height), width: Math.floor(width) };
+};
+
+export default computePreviewElement;

--- a/src/utilities/defaultEventListeners.js
+++ b/src/utilities/defaultEventListeners.js
@@ -1,0 +1,7 @@
+window.oncontextmenu = function () {
+  return false;
+};
+
+document.addEventListener("dragover", function (e) {
+  e.preventDefault();
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,8 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = {
   name: "figmajsx",
   mode: process.env.NODE_ENV || "development",
-  devtool: process.env.NODE_ENV === "production" ? "hidden-source-map" : "eval",
+  devtool:
+    process.env.NODE_ENV === "production" ? false : "eval-cheap-source-map",
   entry: {
     app: "./src/index.js",
   },


### PR DESCRIPTION
원래 기획은 캔버스 생성하는 버튼을 만들어 마지막 캔버스의 오른쪽에 새로운 캔버스가 생기도록 하는 것이었는데, 피그마와 XD 모두 그렇게 하지 않는 것을 확인했다.
그래서 도형을 그리듯 캔버스를 그릴 수 있도록 기획을 변경했다.

중간에 발견한 문제점:
1. 확대/축소 후 캔버스를 생성하려고 아트보드를 드래그 하면 배율이 달라져서 다른 곳에서 캔버스가 그려지는 것
2. 캔버스를 그릴때 mousedown, mousemove 이벤트에 event.offsetX,Y 를 사용했는데 좌표가 튀는 문제

1 번은 마우스 위치와 현재 배율을 계산해서 보정해주도록 수정해서 고침.
2 번은 event.clientX,Y 를 사용해서 고침 (clientX,Y 는 좌표가 안튄다. 왜 그런지는 잘 모르겠다..

https://user-images.githubusercontent.com/108341074/176890275-943de969-bae1-467d-b672-6d76d59afb5f.mov


https://user-images.githubusercontent.com/108341074/176890309-ac0f6c03-5753-40d8-ab32-da6db64569cf.mov

)