### PR TITLE
도형 드래그 앤 드랍 기능

### DIFF
--- a/src/components/atoms/Shape/Shape.module.scss
+++ b/src/components/atoms/Shape/Shape.module.scss
@@ -1,4 +1,9 @@
 .shape {
   position: absolute;
   box-sizing: border-box;
+  backface-visibility: hidden;
+}
+
+.dragging {
+  cursor: grab;
 }

--- a/src/components/atoms/Shape/index.js
+++ b/src/components/atoms/Shape/index.js
@@ -1,7 +1,37 @@
+import { useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+
+import {
+  activateSelector,
+  deactivateSelector,
+} from "../../../features/utility/utilitySlice";
+import useDragShape from "../../../hooks/useDragShape";
 import styles from "./Shape.module.scss";
 
-function Shape({ ...shape }) {
-  return <div className={styles.shape} style={{ ...shape }}></div>;
+function Shape({ canvasIndex, shapeIndex, ...shape }) {
+  const dispatch = useDispatch();
+
+  const shapeRef = useRef();
+
+  const [isMouseHovered, setIsMouseHovered] = useState(false);
+
+  useDragShape(shapeRef, canvasIndex, shapeIndex);
+
+  return (
+    <div
+      ref={shapeRef}
+      className={styles.shape}
+      style={{ ...shape, border: isMouseHovered && "2px solid #b0d0ff" }}
+      onMouseEnter={() => {
+        dispatch(deactivateSelector());
+        setIsMouseHovered(true);
+      }}
+      onMouseLeave={() => {
+        dispatch(activateSelector());
+        setIsMouseHovered(false);
+      }}
+    ></div>
+  );
 }
 
 export default Shape;

--- a/src/components/atoms/ShapeText/index.js
+++ b/src/components/atoms/ShapeText/index.js
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+
 import { modifyShape } from "../../../features/canvas/canvasSlice";
 import {
   selectGlobalColor,
@@ -9,17 +10,22 @@ import {
   activateSelector,
   deactivateSelector,
 } from "../../../features/utility/utilitySlice";
+import useDragShape from "../../../hooks/useDragShape";
 import style from "./ShapeText.module.scss";
 
 function ShapeText({ canvasIndex, shapeIndex, ...canvas }) {
   const dispatch = useDispatch();
+
   const globalColor = useSelector(selectGlobalColor);
   const globalFontSize = useSelector(selectGlobalFontSize);
 
+  const shapeRef = useRef();
   const inputRef = useRef();
 
   const [isDoubleClicked, setIsDoubleClicked] = useState(false);
   const [isMouseHovered, setIsMouseHovered] = useState(false);
+
+  useDragShape(shapeRef, canvasIndex, shapeIndex);
 
   if (isDoubleClicked)
     return (
@@ -57,12 +63,14 @@ function ShapeText({ canvasIndex, shapeIndex, ...canvas }) {
 
   return (
     <div
+      ref={shapeRef}
       className={style.idle}
       style={{
         ...canvas,
         borderBottom: isMouseHovered ? "1px dotted black" : "none",
       }}
       onMouseEnter={() => {
+        console.log("entered");
         dispatch(deactivateSelector());
         setIsMouseHovered(true);
       }}

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import tools from "../constants/tools";
+import { modifyShape, selectAllCanvas } from "../features/canvas/canvasSlice";
+import {
+  selectCurrentScale,
+  selectCurrentTool,
+  selectIsDragScrolling,
+} from "../features/utility/utilitySlice";
+
+let selectionLocked = false;
+
+function useDragShape(shapeRef, canvasIndex, shapeIndex) {
+  const dispatch = useDispatch();
+
+  const currentTool = useSelector(selectCurrentTool);
+  const currentScale = useSelector(selectCurrentScale);
+  const isDragScrolling = useSelector(selectIsDragScrolling);
+  const canvases = useSelector(selectAllCanvas);
+
+  useEffect(() => {
+    if (!shapeRef.current || isDragScrolling || currentTool !== tools.SELECTOR)
+      return;
+
+    const shape = shapeRef.current;
+    let movedTop;
+    let movedLeft;
+
+    const handleMouseDown = (e) => {
+      const originalElPositionTop = e.currentTarget.offsetTop;
+      const originalElPositionLeft = e.currentTarget.offsetLeft;
+      const originalMousePositionTop = e.clientY;
+      const originalMousePositionLeft = e.clientX;
+
+      selectionLocked = true;
+
+      const handleMouseMove = (e) => {
+        movedTop = (e.clientY - originalMousePositionTop) / currentScale;
+        movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
+
+        shape.style.transform = `translate(${movedLeft}px, ${movedTop}px)`;
+      };
+
+      const handleMouseUp = () => {
+        if (!selectionLocked) return;
+
+        const newShapeTop = originalElPositionTop + movedTop;
+        const newShapeLeft = originalElPositionLeft + movedLeft;
+
+        shape.style.removeProperty("transform");
+
+        if (movedTop || movedLeft) {
+          dispatch(
+            modifyShape({
+              top: newShapeTop,
+              left: newShapeLeft,
+              canvasIndex,
+              shapeIndex,
+            })
+          );
+        }
+
+        movedTop = 0;
+        movedLeft = 0;
+        selectionLocked = false;
+
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    };
+
+    shape.addEventListener("mousedown", handleMouseDown);
+
+    return () => {
+      shape.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [
+    canvasIndex,
+    currentScale,
+    currentTool,
+    dispatch,
+    isDragScrolling,
+    shapeIndex,
+    shapeRef,
+    canvases,
+  ]);
+}
+
+export default useDragShape;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,4 +10,9 @@ body {
 
 body {
   background-color: #e4e4e4;
+  overflow: scroll;
+}
+
+body::-webkit-scrollbar {
+  display: none;
 }


### PR DESCRIPTION
### 도형을 드래그 앤 드랍 하는 기능 추가

기술 검증에서는 drag and drop API 를 응용한 방법을 사용해서 구현했는데 그 방법을 적용했더니 배율이 달라짐에 따라 미리보기 이미지의 크기가 바뀌는 문제가 발생했다. 드래그 미리보기 이미지의 크기가 달라지면 사용자 입장에서 드랍 할 때 내 도형이 정확히 어디에 놓일지 모르게 되므로 drag and drop API 를 포기하고 새로운 방법으로 기능을 구축했다. (dataTransfer.setDragImage() 를 사용해서 미리보기 이미지의 크기와 좌표를 만져줄 수 있지만 좌표값을 계산하는데 너무 오랜 시간을 빼았겨서 포기했다)

현재 구축한 방법은 도형을 그릴때 적용했던 방식과 같은 mousedown -> mousemove -> mouseup 이벤트를 연속적으로 걸어준다. 모든 이벤트를 도형에 걸었더니 아래의 영상과 같은 문제가 생겨서 정말 오래 해멨다. 결국 mousemove + mouseup 이벤트는 도형보다 커다란 window 객체에 걸어줌으로서 해결했다.

https://user-images.githubusercontent.com/108341074/177023683-4dc7f81f-8a48-4c64-81c2-59dd0ca92653.mov


