### PR TITLE
도형 선택시 Edit Mode 로 변환

### DIFF
--- a/src/components/atoms/Shape/index.js
+++ b/src/components/atoms/Shape/index.js
@@ -1,36 +1,90 @@
-import { useRef, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useEffect, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import directions from "../../../constants/directions";
 
 import {
   activateSelector,
   deactivateSelector,
+  replaceSelectedShapeIndexes,
+  selectCurrentWorkingCanvasIndex,
+  selectHoveredShape,
+  selectSelectedShapeIndexes,
+  setHoveredShape,
+  setWorkingCanvasIndex,
 } from "../../../features/utility/utilitySlice";
 import useDragShape from "../../../hooks/useDragShape";
+import EditPointer from "../EditPointer";
 import styles from "./Shape.module.scss";
 
-function Shape({ canvasIndex, shapeIndex, ...shape }) {
+function Shape({
+  canvasIndex: currentCanvasIndex,
+  shapeIndex: currentShapeIndex,
+  ...shape
+}) {
   const dispatch = useDispatch();
+
+  const selectedShapeIndexes = useSelector(selectSelectedShapeIndexes);
+  const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
+  const { canvasIndex, shapeIndex } = useSelector(selectHoveredShape);
 
   const shapeRef = useRef();
 
   const [isMouseHovered, setIsMouseHovered] = useState(false);
 
-  useDragShape(shapeRef, canvasIndex, shapeIndex);
+  useDragShape(shapeRef, currentCanvasIndex, currentShapeIndex);
+
+  useEffect(() => {
+    if (
+      canvasIndex === currentCanvasIndex &&
+      shapeIndex === currentShapeIndex
+    ) {
+      return setIsMouseHovered(true);
+    }
+
+    setIsMouseHovered(false);
+  }, [canvasIndex, currentShapeIndex, shapeIndex, currentCanvasIndex]);
 
   return (
-    <div
-      ref={shapeRef}
-      className={styles.shape}
-      style={{ ...shape, border: isMouseHovered && "2px solid #b0d0ff" }}
-      onMouseEnter={() => {
-        dispatch(deactivateSelector());
-        setIsMouseHovered(true);
-      }}
-      onMouseLeave={() => {
-        dispatch(activateSelector());
-        setIsMouseHovered(false);
-      }}
-    ></div>
+    <>
+      <div
+        ref={shapeRef}
+        className={styles.shape}
+        style={{ ...shape, border: isMouseHovered && "2px solid #1673ff" }}
+        onMouseEnter={() => {
+          dispatch(deactivateSelector());
+          dispatch(
+            setHoveredShape({
+              canvasIndex: currentCanvasIndex,
+              shapeIndex: currentShapeIndex,
+            })
+          );
+          setIsMouseHovered(true);
+        }}
+        onMouseLeave={() => {
+          dispatch(activateSelector());
+          dispatch(
+            setHoveredShape({
+              canvasIndex: null,
+              shapeIndex: null,
+            })
+          );
+          setIsMouseHovered(false);
+        }}
+        onClick={() => {
+          if (workingCanvasIndex === currentCanvasIndex) {
+            return dispatch(replaceSelectedShapeIndexes(currentShapeIndex));
+          }
+
+          dispatch(setWorkingCanvasIndex(currentCanvasIndex));
+          dispatch(replaceSelectedShapeIndexes(currentShapeIndex));
+        }}
+      ></div>
+      {workingCanvasIndex === currentCanvasIndex &&
+        selectedShapeIndexes.includes(currentShapeIndex) &&
+        directions.map((direction) => (
+          <EditPointer direction={direction} key={direction} {...shape} />
+        ))}
+    </>
   );
 }
 

--- a/src/components/atoms/TitleText/TitleText.module.scss
+++ b/src/components/atoms/TitleText/TitleText.module.scss
@@ -6,5 +6,5 @@
   padding-left: 20px;
   box-sizing: border-box;
   font-size: $emphasized-font-size;
-  font-weight: $bold-font-weight;
+  font-weight: $medium-font-weight;
 }

--- a/src/features/utility/utilitySlice.js
+++ b/src/features/utility/utilitySlice.js
@@ -7,6 +7,14 @@ const initialState = {
   isSelectorActivated: true,
   isDragScrolling: false,
   isInputFieldFocused: false,
+  workingCanvasIndex: 0,
+  selectedShapeIndexes: [],
+  hoveredShape: {
+    canvasIndex: null,
+    shapeIndex: null,
+  },
+  currentScale: 1,
+  currentTool: tools.SELECTOR,
   tools: [
     tools.RECTANGLE,
     tools.ELLIPSE,
@@ -15,10 +23,6 @@ const initialState = {
     tools.TEXT,
     tools.CANVAS,
   ],
-  workingCanvas: {},
-  selectedShapes: [],
-  currentScale: 1,
-  currentTool: tools.SELECTOR,
 };
 
 const utilitySlice = createSlice({
@@ -52,6 +56,18 @@ const utilitySlice = createSlice({
     setInputFieldBlurred: (state) => {
       state.isInputFieldFocused = false;
     },
+    setWorkingCanvasIndex: (state, { payload }) => {
+      state.workingCanvasIndex = payload;
+    },
+    setHoveredShape: (state, { payload: { canvasIndex, shapeIndex } }) => {
+      state.hoveredShape = { canvasIndex, shapeIndex };
+    },
+    replaceSelectedShapeIndexes: (state, { payload }) => {
+      state.selectedShapeIndexes = [payload];
+    },
+    addSelectedShapeIndexes: (state, { payload }) => {
+      state.selectedShapeIndexes.push(payload);
+    },
   },
 });
 
@@ -65,11 +81,19 @@ export const selectCurrentTool = (state) => state.utility.currentTool;
 
 export const selectIsDragScrolling = (state) => state.utility.isDragScrolling;
 
+export const selectHoveredShape = (state) => state.utility.hoveredShape;
+
+export const selectCurrentWorkingCanvasIndex = (state) =>
+  state.utility.workingCanvasIndex;
+
 export const selectIsSelectorActivated = (state) =>
   state.utility.isSelectorActivated;
 
 export const selectIsInputFieldFocused = (state) =>
   state.utility.isInputFieldFocused;
+
+export const selectSelectedShapeIndexes = (state) =>
+  state.utility.selectedShapeIndexes;
 
 export const {
   activateSelector,
@@ -81,6 +105,10 @@ export const {
   startDragScoll,
   setInputFieldBlurred,
   setInputFieldFocused,
+  setWorkingCanvasIndex,
+  setHoveredShape,
+  addSelectedShapeIndexes,
+  replaceSelectedShapeIndexes,
 } = utilitySlice.actions;
 
 export default utilitySlice.reducer;

--- a/src/hooks/useDrawShape.js
+++ b/src/hooks/useDrawShape.js
@@ -125,6 +125,7 @@ function useDrawShape(elementRef, canvasIndex) {
 
         const coordinates = {
           type: tools.RECTANGLE,
+          name: tools.RECTANGLE,
           top: previewShape.offsetTop,
           left: previewShape.offsetLeft,
           height: previewShape.offsetHeight,
@@ -188,6 +189,7 @@ function useDrawShape(elementRef, canvasIndex) {
 
         const coordinates = {
           type: tools.ELLIPSE,
+          name: tools.ELLIPSE,
           top: previewShape.offsetTop,
           left: previewShape.offsetLeft,
           height: previewShape.offsetHeight,
@@ -255,6 +257,7 @@ function useDrawShape(elementRef, canvasIndex) {
 
         const coordinates = {
           type: tools.LINE,
+          name: tools.LINE,
           top: previewShape.offsetTop,
           left: previewShape.offsetLeft,
           height: previewShape.offsetHeight,
@@ -316,6 +319,7 @@ function useDrawShape(elementRef, canvasIndex) {
 
         const coordinates = {
           type: tools.TEXT,
+          name: tools.TEXT,
           top: previewText.offsetTop,
           left: previewText.offsetLeft,
           text: previewText.innerText,


### PR DESCRIPTION
캘린더의 도형을 클릭하면 주위에 8 개의 점이 달린 Edit Mode 로 바뀐다.

또한 리덕스에 해당 도형이 속한 캔버스의 인덱스와 도형의 인덱스가 저장되어 사이드바에서 참조할 수 있도록 했다.