### PR TITLE
드래그 해서 도형 다중 선택

### DIFF
--- a/src/components/atoms/ArtBoard/index.js
+++ b/src/components/atoms/ArtBoard/index.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import styles from "./ArtBoard.module.scss";
 import useDragToScroll from "../../../hooks/useDragToScroll";
@@ -8,6 +8,7 @@ import Canvas from "../Canvas";
 import useMockZoom from "../../../hooks/useMockZoom";
 import useDrawCanvas from "../../../hooks/useDrawCanvas";
 import useGlobalKeyboardShortCut from "../../../hooks/useGlobalKeyboardShortCut";
+import { emptySelectedShapeIndexes } from "../../../features/utility/utilitySlice";
 
 let isFirstRender = true;
 
@@ -15,6 +16,7 @@ function ArtBoard() {
   const boardRef = useRef();
   const innerBoardRef = useRef();
 
+  const dispatch = useDispatch();
   const canvases = useSelector(selectAllCanvas);
 
   useDragToScroll(boardRef);
@@ -35,6 +37,19 @@ function ArtBoard() {
     boardRef.current.scrollLeft =
       left - boardRef.current.clientWidth / 2 + width / 2;
   }, [canvases]);
+
+  useEffect(() => {
+    if (!innerBoardRef.current) return;
+
+    const artboard = innerBoardRef.current;
+    const resetSelection = () => {
+      dispatch(emptySelectedShapeIndexes());
+    };
+
+    artboard.addEventListener("mousedown", resetSelection);
+
+    return () => artboard.removeEventListener("mousedown", resetSelection);
+  });
 
   return (
     <div ref={boardRef} className={styles["artboard-wrapper"]}>

--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -18,7 +18,7 @@ function Canvas({ canvasIndex, ...canvas }) {
 
   const [isDoubleClicked, setIsDoubleClicked] = useState(false);
 
-  useDrawShape(canvasRef, canvasIndex);
+  useDrawShape(canvasRef, canvasIndex, canvas.children);
 
   useDragCanvas(canvasRef, nameRef, canvasIndex);
 

--- a/src/components/atoms/Shape/index.js
+++ b/src/components/atoms/Shape/index.js
@@ -45,7 +45,7 @@ function Shape({ currentCanvasIndex, currentShapeIndex, ...shape }) {
       <div
         ref={shapeRef}
         className={styles.shape}
-        style={{ ...shape, border: isMouseHovered && "2px solid #1673ff" }}
+        style={{ ...shape, border: isMouseHovered && "1px solid #22a7c3" }}
         onMouseEnter={() => {
           dispatch(deactivateSelector());
           dispatch(

--- a/src/features/globalStyles/globalStylesSlice.js
+++ b/src/features/globalStyles/globalStylesSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-  color: "#000000",
+  color: "#e2e2e2",
   thickness: 1,
   fontSize: 12,
 };

--- a/src/features/utility/utilitySlice.js
+++ b/src/features/utility/utilitySlice.js
@@ -63,6 +63,10 @@ const utilitySlice = createSlice({
       state.hoveredShape = { canvasIndex, shapeIndex };
     },
     replaceSelectedShapeIndexes: (state, { payload }) => {
+      if (typeof payload === "object") {
+        state.selectedShapeIndexes = [...payload];
+        return;
+      }
       state.selectedShapeIndexes = [payload];
     },
     addSelectedShapeIndexes: (state, { payload }) => {

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -28,6 +28,7 @@ function useDragShape(shapeRef, canvasIndex, shapeIndex) {
     let movedLeft;
 
     const handleMouseDown = (e) => {
+      e.stopPropagation();
       const originalElPositionTop = e.currentTarget.offsetTop;
       const originalElPositionLeft = e.currentTarget.offsetLeft;
       const originalMousePositionTop = e.clientY;

--- a/src/hooks/useDrawShape.js
+++ b/src/hooks/useDrawShape.js
@@ -15,12 +15,16 @@ import {
   selectIsDragScrolling,
   setCurrentTool,
   selectIsSelectorActivated,
+  replaceSelectedShapeIndexes,
+  emptySelectedShapeIndexes,
+  setWorkingCanvasIndex,
 } from "../features/utility/utilitySlice";
 import computePreviewElement from "../utilities/computePreviewElement";
 import computePreviewLine from "../utilities/computePreviewLine";
+import computeIntersection from "../utilities/computeIntersection";
 import tools from "../constants/tools";
 
-function useDrawShape(elementRef, canvasIndex) {
+function useDrawShape(elementRef, canvasIndex, shapes) {
   const dispatch = useDispatch();
 
   const currentScale = useSelector(selectCurrentScale);
@@ -54,7 +58,7 @@ function useDrawShape(elementRef, canvasIndex) {
       element.appendChild(previewShape);
 
       const handleMouseMove = (e) => {
-        const { height, left, top, width } = computePreviewElement(
+        const previewShapeStyles = computePreviewElement(
           { x: startLeft, y: startTop },
           {
             x: (e.clientX - elementLeft) / currentScale,
@@ -62,27 +66,37 @@ function useDrawShape(elementRef, canvasIndex) {
           }
         );
 
-        previewShape.style.height = height + "px";
-        previewShape.style.width = width + "px";
-        previewShape.style.top = top + "px";
-        previewShape.style.left = left + "px";
+        const selectedShapeIndexes = [];
+
+        shapes.forEach((shape, i) => {
+          if (computeIntersection(previewShapeStyles, shape)) {
+            selectedShapeIndexes.push(i);
+          }
+        });
+
+        dispatch(replaceSelectedShapeIndexes([...selectedShapeIndexes]));
+
+        previewShape.style.height = previewShapeStyles.height + "px";
+        previewShape.style.width = previewShapeStyles.width + "px";
+        previewShape.style.top = previewShapeStyles.top + "px";
+        previewShape.style.left = previewShapeStyles.left + "px";
       };
 
       const handleMouseUp = () => {
         if (e.button === 2) {
           previewShape.remove();
-          element.removeEventListener("mousemove", handleMouseMove);
-          element.removeEventListener("mouseup", handleMouseUp);
+          window.removeEventListener("mousemove", handleMouseMove);
+          window.removeEventListener("mouseup", handleMouseUp);
           return;
         }
 
         previewShape.remove();
-        element.removeEventListener("mousemove", handleMouseMove);
-        element.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
       };
 
-      element.addEventListener("mousemove", handleMouseMove);
-      element.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
     };
 
     const handleMouseDownRectangle = (e) => {
@@ -120,8 +134,8 @@ function useDrawShape(elementRef, canvasIndex) {
       const handleMouseUp = () => {
         if (e.button === 2) {
           previewShape.remove();
-          element.removeEventListener("mousemove", handleMouseMove);
-          element.removeEventListener("mouseup", handleMouseUp);
+          window.removeEventListener("mousemove", handleMouseMove);
+          window.removeEventListener("mouseup", handleMouseUp);
           return;
         }
 
@@ -140,12 +154,12 @@ function useDrawShape(elementRef, canvasIndex) {
           dispatch(addShape(coordinates));
 
         previewShape.remove();
-        element.removeEventListener("mousemove", handleMouseMove);
-        element.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
       };
 
-      element.addEventListener("mousemove", handleMouseMove);
-      element.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
     };
 
     const handleMouseDownEllipse = (e) => {
@@ -184,8 +198,8 @@ function useDrawShape(elementRef, canvasIndex) {
       const handleMouseUp = () => {
         if (e.button === 2) {
           previewShape.remove();
-          element.removeEventListener("mousemove", handleMouseMove);
-          element.removeEventListener("mouseup", handleMouseUp);
+          window.removeEventListener("mousemove", handleMouseMove);
+          window.removeEventListener("mouseup", handleMouseUp);
           return;
         }
 
@@ -205,12 +219,12 @@ function useDrawShape(elementRef, canvasIndex) {
           dispatch(addShape(coordinates));
 
         previewShape.remove();
-        element.removeEventListener("mousemove", handleMouseMove);
-        element.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
       };
 
-      element.addEventListener("mousemove", handleMouseMove);
-      element.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
     };
 
     const handleMouseDownLine = (e) => {
@@ -252,8 +266,8 @@ function useDrawShape(elementRef, canvasIndex) {
       const handleMouseUp = () => {
         if (e.button === 2) {
           previewShape.remove();
-          element.removeEventListener("mousemove", handleMouseMove);
-          element.removeEventListener("mouseup", handleMouseUp);
+          window.removeEventListener("mousemove", handleMouseMove);
+          window.removeEventListener("mouseup", handleMouseUp);
           return;
         }
 
@@ -272,12 +286,12 @@ function useDrawShape(elementRef, canvasIndex) {
           dispatch(addShape(coordinates));
 
         previewShape.remove();
-        element.removeEventListener("mousemove", handleMouseMove);
-        element.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
       };
 
-      element.addEventListener("mousemove", handleMouseMove);
-      element.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
     };
 
     const handleClickText = (e) => {
@@ -342,18 +356,28 @@ function useDrawShape(elementRef, canvasIndex) {
     if (currentTool === tools.SELECTOR) {
       if (!isSelectorActivated) return;
 
+      const resetSelection = (e) => {
+        e.stopPropagation();
+        dispatch(setWorkingCanvasIndex(canvasIndex));
+        dispatch(emptySelectedShapeIndexes());
+      };
+
       element.style.cursor = "default";
       element.addEventListener("mousedown", handleMouseDownSelector);
+      element.addEventListener("mousedown", resetSelection);
 
-      return () =>
+      return () => {
         element.removeEventListener("mousedown", handleMouseDownSelector);
+        element.removeEventListener("mousedown", resetSelection);
+      };
     }
     if (currentTool === tools.RECTANGLE) {
       element.style.cursor = "crosshair";
       element.addEventListener("mousedown", handleMouseDownRectangle);
 
-      return () =>
+      return () => {
         element.removeEventListener("mousedown", handleMouseDownRectangle);
+      };
     }
     if (currentTool === tools.ELLIPSE) {
       element.style.cursor = "crosshair";
@@ -386,6 +410,7 @@ function useDrawShape(elementRef, canvasIndex) {
     isDragScrolling,
     isSelectorActivated,
     globalThickness,
+    shapes,
   ]);
 }
 


### PR DESCRIPTION
캔버스에서 드래그 해서 드래그 한 영역 내에 있는 모든 도형을 선택 상태로 바꿔주는 로직을 작성했다.

추가로, 캔버스 내부에서 드래그 또는 도형을 그릴 때 캔버스 밖으로 드래그가 이어질 수 있도록 window 객체에 이벤트를 걸어줬다. 이전에는 캔버스 요소에 이벤트가 걸려있었다.