### PR TITLE
도형 드래그 스냅 기능

### DIFF
--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -74,6 +74,7 @@ function Canvas({ canvasIndex, ...canvas }) {
               key={i}
               currentCanvasIndex={canvasIndex}
               currentShapeIndex={i}
+              canvasRef={canvasRef}
               {...shape}
             />
           ) : (
@@ -81,6 +82,7 @@ function Canvas({ canvasIndex, ...canvas }) {
               key={i}
               currentCanvasIndex={canvasIndex}
               currentShapeIndex={i}
+              canvasRef={canvasRef}
               {...shape}
             />
           )

--- a/src/components/atoms/Shape/index.js
+++ b/src/components/atoms/Shape/index.js
@@ -13,7 +13,7 @@ import {
 import useDragShape from "../../../hooks/useDragShape";
 import styles from "./Shape.module.scss";
 
-function Shape({ currentCanvasIndex, currentShapeIndex, ...shape }) {
+function Shape({ canvasRef, currentCanvasIndex, currentShapeIndex, ...shape }) {
   const dispatch = useDispatch();
 
   const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
@@ -23,7 +23,7 @@ function Shape({ currentCanvasIndex, currentShapeIndex, ...shape }) {
 
   const [isMouseHovered, setIsMouseHovered] = useState(false);
 
-  useDragShape(shapeRef, currentCanvasIndex, currentShapeIndex);
+  useDragShape(shapeRef, canvasRef, currentCanvasIndex, currentShapeIndex);
 
   useEffect(() => {
     if (

--- a/src/components/atoms/ShapeText/index.js
+++ b/src/components/atoms/ShapeText/index.js
@@ -36,7 +36,7 @@ function ShapeText({
 
   const [isDoubleClicked, setIsDoubleClicked] = useState(false);
   const [isMouseHovered, setIsMouseHovered] = useState(false);
-  console.log("...canvas", canvas);
+
   useDragShape(
     shapeRef,
     canvasRef,

--- a/src/components/atoms/ShapeText/index.js
+++ b/src/components/atoms/ShapeText/index.js
@@ -18,7 +18,12 @@ import {
 import useDragShape from "../../../hooks/useDragShape";
 import style from "./ShapeText.module.scss";
 
-function ShapeText({ currentCanvasIndex, currentShapeIndex, ...canvas }) {
+function ShapeText({
+  canvasRef,
+  currentCanvasIndex,
+  currentShapeIndex,
+  ...canvas
+}) {
   const dispatch = useDispatch();
 
   const globalColor = useSelector(selectGlobalColor);
@@ -31,9 +36,10 @@ function ShapeText({ currentCanvasIndex, currentShapeIndex, ...canvas }) {
 
   const [isDoubleClicked, setIsDoubleClicked] = useState(false);
   const [isMouseHovered, setIsMouseHovered] = useState(false);
-
+  console.log("...canvas", canvas);
   useDragShape(
     shapeRef,
+    canvasRef,
     currentCanvasIndex,
     currentShapeIndex,
     !isDoubleClicked

--- a/src/components/pages/WorkbenchPage/index.js
+++ b/src/components/pages/WorkbenchPage/index.js
@@ -6,14 +6,14 @@ import Header from "../../molecules/Header";
 
 function WorkbenchPage() {
   return (
-    <div>
+    <>
       <Header />
       <div className={styles.workbench}>
         <LeftSideBar />
         <ArtBoard />
         <RightSideBar />
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/features/canvas/canvasSlice.js
+++ b/src/features/canvas/canvasSlice.js
@@ -11,8 +11,6 @@ const generateSampleCanvas = (
   left,
   width,
   height,
-  xAxisSnap: [0, width / 2, width],
-  yAxisSnap: [0, height / 2, height],
   selectedShapes: [],
   children: [],
 });
@@ -71,12 +69,6 @@ const canvasSlice = createSlice({
 });
 
 export const selectAllCanvas = (state) => state.workbench.present.canvas;
-
-export const selectXAxisSnapPoints = (canvasIdx) => (state) =>
-  state.workbench.present.canvas[canvasIdx].xAxisSnap;
-
-export const selectYAxisSnapPoints = (canvasIdx) => (state) =>
-  state.workbench.present.canvas[canvasIdx].yAxisSnap;
 
 export const {
   createCanvas,

--- a/src/features/canvas/canvasSlice.js
+++ b/src/features/canvas/canvasSlice.js
@@ -1,4 +1,4 @@
-import { createSlice, current } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
 
 const generateSampleCanvas = (
   top = 1000,
@@ -28,7 +28,6 @@ const canvasSlice = createSlice({
         ...generateSampleCanvas(top, left, width, height),
         canvasName: `canvas_${state.length}`,
       };
-
       state.push(newCanvas);
     },
     changeCanvasName: (state, { payload: { name, canvasIndex } }) => {
@@ -45,25 +44,7 @@ const canvasSlice = createSlice({
     addShape: (state, { payload }) => {
       const index = payload.canvasIndex;
       delete payload.canvasIndex;
-      const xAxisSnaps = [
-        payload.left,
-        payload.left + payload.width / 2,
-        payload.left + payload.width,
-      ];
-      const yAxisSnaps = [
-        payload.top,
-        payload.top + payload.height / 2,
-        payload.top + payload.height,
-      ];
-      const xAxisSnapSet = new Set(
-        current(state[index].xAxisSnap).concat(xAxisSnaps)
-      );
-      const yAxisSnapSet = new Set(
-        current(state[index].yAxisSnap).concat(yAxisSnaps)
-      );
       state[index].children.push(payload);
-      state[index].xAxisSnap.push(...[...xAxisSnapSet]);
-      state[index].yAxisSnap.push(...[...yAxisSnapSet]);
       payload.name = `${payload.type} ${state[index].children.length}`;
     },
     modifyShape: (state, { payload }) => {
@@ -74,49 +55,6 @@ const canvasSlice = createSlice({
       state[canvasIndex].children[shapeIndex] = {
         ...state[canvasIndex].children[shapeIndex],
         ...payload,
-      };
-    },
-    changeShapePosition: (state, { payload }) => {
-      const canvasIndex = payload.canvasIndex;
-      const shapeIndex = payload.shapeIndex;
-      const prevXAxisSnaps = [
-        payload.prevLeft,
-        payload.prevLeft + payload.prevWidth / 2,
-        payload.prevLeft + payload.prevWidth,
-      ];
-      const prevYAxisSnaps = [
-        payload.prevTop,
-        payload.prevTop + payload.prevHeight / 2,
-        payload.prevTop + payload.prevHeight,
-      ];
-      const xAxisSnaps = [
-        payload.left,
-        payload.left + payload.prevWidth / 2,
-        payload.left + payload.prevWidth,
-      ];
-      const yAxisSnaps = [
-        payload.top,
-        payload.top + payload.prevHeight / 2,
-        payload.top + payload.prevHeight,
-      ];
-      const filteredXAxisSnaps = [];
-      current(state[canvasIndex].xAxisSnap).forEach((num) => {
-        if (!prevXAxisSnaps.includes(num)) filteredXAxisSnaps.push(num);
-      });
-      const filteredYAxisSnaps = [];
-      current(state[canvasIndex].yAxisSnap).forEach((num) => {
-        if (!prevYAxisSnaps.includes(num)) filteredYAxisSnaps.push(num);
-      });
-      const newXAxisSnap = new Set(filteredXAxisSnaps.concat(xAxisSnaps));
-      const newYAxisSnap = new Set(filteredYAxisSnaps.concat(yAxisSnaps));
-      state[canvasIndex].xAxisSnap = [...newXAxisSnap];
-      state[canvasIndex].yAxisSnap = [...newYAxisSnap];
-      state[canvasIndex].children[shapeIndex] = {
-        ...state[canvasIndex].children[shapeIndex],
-        ...{
-          top: payload.top,
-          left: payload.left,
-        },
       };
     },
     changeShapeIndex: (state, { payload: { canvasIdx, fromIdx, toIdx } }) => {
@@ -148,7 +86,6 @@ export const {
   changeShapeIndex,
   modifyCanvas,
   deleteShape,
-  changeShapePosition,
 } = canvasSlice.actions;
 
 export default canvasSlice.reducer;

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -2,25 +2,39 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import tools from "../constants/tools";
-import { modifyShape } from "../features/canvas/canvasSlice";
+import {
+  changeShapePosition,
+  selectXAxisSnapPoints,
+  selectYAxisSnapPoints,
+} from "../features/canvas/canvasSlice";
 import {
   selectCurrentScale,
   selectCurrentTool,
   selectIsDragScrolling,
 } from "../features/utility/utilitySlice";
+import computeSnapPosition from "../utilities/computeSnapPosition";
 
-let selectionLocked = false;
+const GRAVITY = 10;
 
-function useDragShape(shapeRef, canvasIndex, shapeIndex, isRendered = true) {
+function useDragShape(
+  shapeRef,
+  canvasRef,
+  canvasIndex,
+  shapeIndex,
+  isRendered = true
+) {
   const dispatch = useDispatch();
 
   const currentTool = useSelector(selectCurrentTool);
   const currentScale = useSelector(selectCurrentScale);
   const isDragScrolling = useSelector(selectIsDragScrolling);
+  const xAxisSnapPoints = useSelector(selectXAxisSnapPoints(canvasIndex));
+  const yAxisSnapPoints = useSelector(selectYAxisSnapPoints(canvasIndex));
 
   useEffect(() => {
     if (
       !shapeRef.current ||
+      !canvasRef.current ||
       isDragScrolling ||
       currentTool !== tools.SELECTOR ||
       !isRendered
@@ -28,54 +42,267 @@ function useDragShape(shapeRef, canvasIndex, shapeIndex, isRendered = true) {
       return;
 
     const shape = shapeRef.current;
-    let movedTop;
-    let movedLeft;
+    const canvas = canvasRef.current;
 
     const handleMouseDown = (e) => {
       e.stopPropagation();
+      const horTopLine = document.createElement("div");
+      const horBotLine = document.createElement("div");
+      const verLeftLine = document.createElement("div");
+      const verRightLine = document.createElement("div");
+
       const originalElPositionTop = e.currentTarget.offsetTop;
       const originalElPositionLeft = e.currentTarget.offsetLeft;
+      const originalElHeight = e.currentTarget.offsetHeight;
+      const originalElWidth = e.currentTarget.offsetWidth;
       const originalMousePositionTop = e.clientY;
       const originalMousePositionLeft = e.clientX;
 
-      selectionLocked = true;
+      let movedTop;
+      let movedLeft;
+      let isLocked = false; // eslint-disable-line no-unused-vars
+      let isLeftAttached = false;
+      let isRightAttached = false;
+      let isTopAttached = false;
+      let isBottomAttached = false;
+      let nearestPossibleSnapAtX;
+      let nearestPossibleSnapAtY;
+
+      canvas.appendChild(horTopLine);
+      canvas.appendChild(horBotLine);
+      canvas.appendChild(verLeftLine);
+      canvas.appendChild(verRightLine);
 
       const handleMouseMove = (e) => {
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
-        shape.style.transform = `translate(${movedLeft}px, ${movedTop}px)`;
+        const currentLeft = originalElPositionLeft + movedLeft;
+        const currentTop = originalElPositionTop + movedTop;
+
+        horTopLine.style.visibility = "hidden";
+        horBotLine.style.visibility = "hidden";
+        verLeftLine.style.visibility = "hidden";
+        verRightLine.style.visibility = "hidden";
+
+        nearestPossibleSnapAtX = computeSnapPosition(
+          xAxisSnapPoints,
+          currentLeft,
+          currentLeft + originalElWidth
+        );
+        nearestPossibleSnapAtY = computeSnapPosition(
+          yAxisSnapPoints,
+          currentTop,
+          currentTop + originalElHeight
+        );
+
+        if (Math.abs(currentLeft - nearestPossibleSnapAtX) < GRAVITY) {
+          shape.style.left = nearestPossibleSnapAtX + "px";
+          isLocked = true;
+          isLeftAttached = true;
+        } else if (
+          Math.abs(currentLeft + originalElWidth - nearestPossibleSnapAtX) <
+          GRAVITY
+        ) {
+          shape.style.left = nearestPossibleSnapAtX - originalElWidth + "px";
+          isLocked = true;
+          isRightAttached = true;
+        } else {
+          shape.style.left = currentLeft + "px";
+          isLocked = false;
+          isLeftAttached = false;
+          isRightAttached = false;
+        }
+
+        if (Math.abs(currentTop - nearestPossibleSnapAtY) < GRAVITY) {
+          shape.style.top = nearestPossibleSnapAtY + "px";
+          isLocked = true;
+          isTopAttached = true;
+        } else if (
+          Math.abs(currentTop + originalElHeight - nearestPossibleSnapAtY) <
+          GRAVITY
+        ) {
+          shape.style.top = nearestPossibleSnapAtY - originalElHeight + "px";
+          isLocked = true;
+          isBottomAttached = true;
+        } else {
+          shape.style.top = currentTop + "px";
+          isLocked = false;
+          isTopAttached = false;
+          isBottomAttached = false;
+        }
+
+        if (isLeftAttached) {
+          verLeftLine.style.visibility = "visible";
+          verLeftLine.style.left = nearestPossibleSnapAtX + "px";
+          verLeftLine.style.position = "absolute";
+          verLeftLine.style.width = "1px";
+          verLeftLine.style.height = "100%";
+          verLeftLine.style.backgroundColor = "#c8deff";
+        } else if (isRightAttached) {
+          verRightLine.style.visibility = "visible";
+          verRightLine.style.left = nearestPossibleSnapAtX + "px";
+          verRightLine.style.position = "absolute";
+          verRightLine.style.width = "1px";
+          verRightLine.style.height = "100%";
+          verRightLine.style.backgroundColor = "#c8deff";
+        }
+
+        if (isTopAttached) {
+          horTopLine.style.visibility = "visible";
+          horTopLine.style.top = nearestPossibleSnapAtY + "px";
+          horTopLine.style.position = "absolute";
+          horTopLine.style.width = "100%";
+          horTopLine.style.height = "1px";
+          horTopLine.style.backgroundColor = "#c8deff";
+        } else if (isBottomAttached) {
+          horBotLine.style.visibility = "visible";
+          horBotLine.style.top = nearestPossibleSnapAtY + "px";
+          horBotLine.style.position = "absolute";
+          horBotLine.style.width = "100%";
+          horBotLine.style.height = "1px";
+          horBotLine.style.backgroundColor = "#c8deff";
+        }
       };
 
       const handleMouseUp = () => {
-        if (!selectionLocked) return;
-
         const newShapeTop = originalElPositionTop + movedTop;
         const newShapeLeft = originalElPositionLeft + movedLeft;
 
-        shape.style.removeProperty("transform");
+        horBotLine.remove();
+        horTopLine.remove();
+        verLeftLine.remove();
+        verRightLine.remove();
 
         if (movedTop || movedLeft) {
-          dispatch(
-            modifyShape({
-              top: newShapeTop,
-              left: newShapeLeft,
-              canvasIndex,
-              shapeIndex,
-            })
-          );
+          if (isLeftAttached && isTopAttached) {
+            dispatch(
+              changeShapePosition({
+                top: nearestPossibleSnapAtY,
+                left: nearestPossibleSnapAtX,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isLeftAttached && isBottomAttached) {
+            dispatch(
+              changeShapePosition({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: nearestPossibleSnapAtX,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isRightAttached && isTopAttached) {
+            dispatch(
+              changeShapePosition({
+                top: nearestPossibleSnapAtY,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isRightAttached && isBottomAttached) {
+            dispatch(
+              changeShapePosition({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isLeftAttached) {
+            dispatch(
+              changeShapePosition({
+                top: newShapeTop,
+                left: nearestPossibleSnapAtX,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isRightAttached) {
+            dispatch(
+              changeShapePosition({
+                top: newShapeTop,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isTopAttached) {
+            dispatch(
+              changeShapePosition({
+                top: nearestPossibleSnapAtY,
+                left: newShapeLeft,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isBottomAttached) {
+            dispatch(
+              changeShapePosition({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: newShapeLeft,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else {
+            dispatch(
+              changeShapePosition({
+                top: newShapeTop,
+                left: newShapeLeft,
+                prevTop: originalElPositionTop,
+                prevLeft: originalElPositionLeft,
+                prevHeight: originalElHeight,
+                prevWidth: originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          }
         }
 
         movedTop = 0;
         movedLeft = 0;
-        selectionLocked = false;
 
         window.removeEventListener("mousemove", handleMouseMove);
-        window.removeEventListener("mouseup", handleMouseUp);
       };
 
       window.addEventListener("mousemove", handleMouseMove);
-      window.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("mouseup", handleMouseUp, { once: true });
     };
 
     shape.addEventListener("mousedown", handleMouseDown);
@@ -85,6 +312,7 @@ function useDragShape(shapeRef, canvasIndex, shapeIndex, isRendered = true) {
     };
   }, [
     canvasIndex,
+    canvasRef,
     currentScale,
     currentTool,
     dispatch,
@@ -92,6 +320,8 @@ function useDragShape(shapeRef, canvasIndex, shapeIndex, isRendered = true) {
     isRendered,
     shapeIndex,
     shapeRef,
+    xAxisSnapPoints,
+    yAxisSnapPoints,
   ]);
 }
 

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -41,10 +41,9 @@ function useDragShape(
 
     const handleMouseDown = (e) => {
       e.stopPropagation();
-      const horTopLine = document.createElement("div");
-      const horBotLine = document.createElement("div");
-      const verLeftLine = document.createElement("div");
-      const verRightLine = document.createElement("div");
+
+      const verticalLine = document.createElement("div");
+      const horizontalLine = document.createElement("div");
 
       const originalElPositionTop = e.currentTarget.offsetTop;
       const originalElPositionLeft = e.currentTarget.offsetLeft;
@@ -89,15 +88,15 @@ function useDragShape(
       let isLocked = false; // eslint-disable-line no-unused-vars
       let isLeftAttached = false;
       let isRightAttached = false;
+      let isVerMidAttached = false;
       let isTopAttached = false;
       let isBottomAttached = false;
+      let isHorMidAttached = false;
       let nearestPossibleSnapAtX;
       let nearestPossibleSnapAtY;
 
-      canvas.appendChild(horTopLine);
-      canvas.appendChild(horBotLine);
-      canvas.appendChild(verLeftLine);
-      canvas.appendChild(verRightLine);
+      canvas.appendChild(verticalLine);
+      canvas.appendChild(horizontalLine);
 
       const handleMouseMove = (e) => {
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
@@ -106,20 +105,29 @@ function useDragShape(
         const currentLeft = originalElPositionLeft + movedLeft;
         const currentTop = originalElPositionTop + movedTop;
 
-        horTopLine.style.visibility = "hidden";
-        horBotLine.style.visibility = "hidden";
-        verLeftLine.style.visibility = "hidden";
-        verRightLine.style.visibility = "hidden";
+        verticalLine.style.visibility = "hidden";
+        verticalLine.style.position = "absolute";
+        verticalLine.style.width = "1px";
+        verticalLine.style.height = "100%";
+        verticalLine.style.backgroundColor = "#c8deff";
+
+        horizontalLine.style.visibility = "hidden";
+        horizontalLine.style.position = "absolute";
+        horizontalLine.style.width = "100%";
+        horizontalLine.style.height = "1px";
+        horizontalLine.style.backgroundColor = "#c8deff";
 
         nearestPossibleSnapAtX = computeSnapPosition(
           filteredXAxisSnapPoints,
           currentLeft,
-          currentLeft + originalElWidth
+          currentLeft + originalElWidth,
+          currentLeft + originalElWidth / 2
         );
         nearestPossibleSnapAtY = computeSnapPosition(
           filteredYAxisSnapPoints,
           currentTop,
-          currentTop + originalElHeight
+          currentTop + originalElHeight,
+          currentTop + originalElHeight / 2
         );
 
         if (Math.abs(currentLeft - nearestPossibleSnapAtX) < GRAVITY) {
@@ -127,6 +135,7 @@ function useDragShape(
           isLocked = true;
           isLeftAttached = true;
           isRightAttached = false;
+          isVerMidAttached = false;
         } else if (
           Math.abs(currentLeft + originalElWidth - nearestPossibleSnapAtX) <
           GRAVITY
@@ -135,11 +144,23 @@ function useDragShape(
           isLocked = true;
           isRightAttached = true;
           isLeftAttached = false;
+          isVerMidAttached = false;
+        } else if (
+          Math.abs(currentLeft + originalElWidth / 2 - nearestPossibleSnapAtX) <
+          GRAVITY
+        ) {
+          shape.style.left =
+            nearestPossibleSnapAtX - originalElWidth / 2 + "px";
+          isLocked = true;
+          isRightAttached = false;
+          isLeftAttached = false;
+          isVerMidAttached = true;
         } else {
           shape.style.left = currentLeft + "px";
           isLocked = false;
           isLeftAttached = false;
           isRightAttached = false;
+          isVerMidAttached = false;
         }
 
         if (Math.abs(currentTop - nearestPossibleSnapAtY) < GRAVITY) {
@@ -147,6 +168,7 @@ function useDragShape(
           isLocked = true;
           isTopAttached = true;
           isBottomAttached = false;
+          isHorMidAttached = false;
         } else if (
           Math.abs(currentTop + originalElHeight - nearestPossibleSnapAtY) <
           GRAVITY
@@ -155,43 +177,33 @@ function useDragShape(
           isLocked = true;
           isBottomAttached = true;
           isTopAttached = false;
+          isHorMidAttached = false;
+        } else if (
+          Math.abs(currentTop + originalElHeight / 2 - nearestPossibleSnapAtY) <
+          GRAVITY
+        ) {
+          shape.style.top =
+            nearestPossibleSnapAtY - originalElHeight / 2 + "px";
+          isLocked = true;
+          isBottomAttached = false;
+          isTopAttached = false;
+          isHorMidAttached = true;
         } else {
           shape.style.top = currentTop + "px";
           isLocked = false;
           isTopAttached = false;
           isBottomAttached = false;
+          isHorMidAttached = false;
         }
 
-        if (isLeftAttached) {
-          verLeftLine.style.visibility = "visible";
-          verLeftLine.style.left = nearestPossibleSnapAtX + "px";
-          verLeftLine.style.position = "absolute";
-          verLeftLine.style.width = "1px";
-          verLeftLine.style.height = "100%";
-          verLeftLine.style.backgroundColor = "#c8deff";
-        } else if (isRightAttached) {
-          verRightLine.style.visibility = "visible";
-          verRightLine.style.left = nearestPossibleSnapAtX + "px";
-          verRightLine.style.position = "absolute";
-          verRightLine.style.width = "1px";
-          verRightLine.style.height = "100%";
-          verRightLine.style.backgroundColor = "#c8deff";
+        if (isLeftAttached || isRightAttached || isVerMidAttached) {
+          verticalLine.style.visibility = "visible";
+          verticalLine.style.left = nearestPossibleSnapAtX + "px";
         }
 
-        if (isTopAttached) {
-          horTopLine.style.visibility = "visible";
-          horTopLine.style.top = nearestPossibleSnapAtY + "px";
-          horTopLine.style.position = "absolute";
-          horTopLine.style.width = "100%";
-          horTopLine.style.height = "1px";
-          horTopLine.style.backgroundColor = "#c8deff";
-        } else if (isBottomAttached) {
-          horBotLine.style.visibility = "visible";
-          horBotLine.style.top = nearestPossibleSnapAtY + "px";
-          horBotLine.style.position = "absolute";
-          horBotLine.style.width = "100%";
-          horBotLine.style.height = "1px";
-          horBotLine.style.backgroundColor = "#c8deff";
+        if (isTopAttached || isBottomAttached || isHorMidAttached) {
+          horizontalLine.style.visibility = "visible";
+          horizontalLine.style.top = nearestPossibleSnapAtY + "px";
         }
       };
 
@@ -199,10 +211,8 @@ function useDragShape(
         const newShapeTop = originalElPositionTop + movedTop;
         const newShapeLeft = originalElPositionLeft + movedLeft;
 
-        horBotLine.remove();
-        horTopLine.remove();
-        verLeftLine.remove();
-        verRightLine.remove();
+        verticalLine.remove();
+        horizontalLine.remove();
 
         if (movedTop || movedLeft) {
           if (isLeftAttached && isTopAttached) {
@@ -237,6 +247,69 @@ function useDragShape(
               modifyShape({
                 top: nearestPossibleSnapAtY - originalElHeight,
                 left: nearestPossibleSnapAtX - originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isLeftAttached && isHorMidAttached) {
+            dispatch(
+              modifyShape({
+                top: nearestPossibleSnapAtY - originalElHeight / 2,
+                left: nearestPossibleSnapAtX,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isRightAttached && isHorMidAttached) {
+            dispatch(
+              modifyShape({
+                top: nearestPossibleSnapAtY - originalElHeight / 2,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isTopAttached && isVerMidAttached) {
+            dispatch(
+              modifyShape({
+                top: nearestPossibleSnapAtY,
+                left: nearestPossibleSnapAtX - originalElWidth / 2,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isBottomAttached && isVerMidAttached) {
+            dispatch(
+              modifyShape({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: nearestPossibleSnapAtX - originalElWidth / 2,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isHorMidAttached && isVerMidAttached) {
+            dispatch(
+              modifyShape({
+                top: nearestPossibleSnapAtY - originalElHeight / 2,
+                left: nearestPossibleSnapAtX - originalElWidth / 2,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isHorMidAttached) {
+            dispatch(
+              modifyShape({
+                top: nearestPossibleSnapAtY - originalElHeight / 2,
+                left: newShapeLeft,
+                canvasIndex,
+                shapeIndex,
+              })
+            );
+          } else if (isVerMidAttached) {
+            dispatch(
+              modifyShape({
+                top: newShapeTop,
+                left: nearestPossibleSnapAtX - originalElWidth / 2,
                 canvasIndex,
                 shapeIndex,
               })

--- a/src/utilities/computeSelectionBox.js
+++ b/src/utilities/computeSelectionBox.js
@@ -1,0 +1,21 @@
+function computeSelectionBox(shapes, selectedIdxArr) {
+  const result = {
+    top: Number.MAX_SAFE_INTEGER,
+    left: Number.MAX_SAFE_INTEGER,
+    height: Number.MIN_SAFE_INTEGER,
+    width: Number.MIN_SAFE_INTEGER,
+  };
+
+  shapes.forEach((obj, i) => {
+    if (selectedIdxArr.includes(i)) {
+      result.top = Math.min(result.top, obj.top);
+      result.left = Math.min(result.left, obj.left);
+      result.height = Math.max(result.height, obj.height + obj.top);
+      result.width = Math.max(result.width, obj.width + obj.left);
+    }
+  });
+
+  return result;
+}
+
+export default computeSelectionBox;

--- a/src/utilities/computeSnapPosition.js
+++ b/src/utilities/computeSnapPosition.js
@@ -1,0 +1,34 @@
+function computeSnapPosition(snappables, left, right) {
+  let nearestDistanceFromLeft = Number.MAX_SAFE_INTEGER;
+  let snappablePositionFromLeft;
+
+  snappables.forEach((position) => {
+    const distance = Math.abs(position - left);
+
+    nearestDistanceFromLeft = Math.min(nearestDistanceFromLeft, distance);
+
+    if (nearestDistanceFromLeft === distance) {
+      snappablePositionFromLeft = position;
+    }
+  });
+
+  let nearestDistanceFromRight = Number.MAX_SAFE_INTEGER;
+  let snappablePositionFromRight;
+
+  snappables.forEach((position) => {
+    const distance = Math.abs(position - right);
+
+    nearestDistanceFromRight = Math.min(nearestDistanceFromRight, distance);
+
+    if (nearestDistanceFromRight === distance) {
+      snappablePositionFromRight = position;
+    }
+  });
+
+  if (nearestDistanceFromLeft < nearestDistanceFromRight) {
+    return snappablePositionFromLeft;
+  }
+
+  return snappablePositionFromRight;
+}
+export default computeSnapPosition;

--- a/src/utilities/computeSnapPosition.js
+++ b/src/utilities/computeSnapPosition.js
@@ -1,34 +1,34 @@
-function computeSnapPosition(snappables, left, right) {
-  let nearestDistanceFromLeft = Number.MAX_SAFE_INTEGER;
-  let snappablePositionFromLeft;
+function computeSnapPosition(snappables, pointA, pointB) {
+  let nearestDistanceFromPointA = Number.MAX_SAFE_INTEGER;
+  let snappablePositionFromPointA;
 
   snappables.forEach((position) => {
-    const distance = Math.abs(position - left);
+    const distance = Math.abs(position - pointA);
 
-    nearestDistanceFromLeft = Math.min(nearestDistanceFromLeft, distance);
+    nearestDistanceFromPointA = Math.min(nearestDistanceFromPointA, distance);
 
-    if (nearestDistanceFromLeft === distance) {
-      snappablePositionFromLeft = position;
+    if (nearestDistanceFromPointA === distance) {
+      snappablePositionFromPointA = position;
     }
   });
 
-  let nearestDistanceFromRight = Number.MAX_SAFE_INTEGER;
-  let snappablePositionFromRight;
+  let nearestDistanceFromPointB = Number.MAX_SAFE_INTEGER;
+  let snappablePositionFromPointB;
 
   snappables.forEach((position) => {
-    const distance = Math.abs(position - right);
+    const distance = Math.abs(position - pointB);
 
-    nearestDistanceFromRight = Math.min(nearestDistanceFromRight, distance);
+    nearestDistanceFromPointB = Math.min(nearestDistanceFromPointB, distance);
 
-    if (nearestDistanceFromRight === distance) {
-      snappablePositionFromRight = position;
+    if (nearestDistanceFromPointB === distance) {
+      snappablePositionFromPointB = position;
     }
   });
 
-  if (nearestDistanceFromLeft < nearestDistanceFromRight) {
-    return snappablePositionFromLeft;
+  if (nearestDistanceFromPointA < nearestDistanceFromPointB) {
+    return snappablePositionFromPointA;
   }
 
-  return snappablePositionFromRight;
+  return snappablePositionFromPointB;
 }
 export default computeSnapPosition;

--- a/src/utilities/computeSnapPosition.js
+++ b/src/utilities/computeSnapPosition.js
@@ -1,4 +1,4 @@
-function computeSnapPosition(snappables, pointA, pointB) {
+function computeSnapPosition(snappables, pointA, pointB, pointC) {
   let nearestDistanceFromPointA = Number.MAX_SAFE_INTEGER;
   let snappablePositionFromPointA;
 
@@ -25,10 +25,32 @@ function computeSnapPosition(snappables, pointA, pointB) {
     }
   });
 
-  if (nearestDistanceFromPointA < nearestDistanceFromPointB) {
-    return snappablePositionFromPointA;
-  }
+  let nearestDistanceFromPointC = Number.MAX_SAFE_INTEGER;
+  let snappablePositionFromPointC;
 
-  return snappablePositionFromPointB;
+  snappables.forEach((position) => {
+    const distance = Math.abs(position - pointC);
+
+    nearestDistanceFromPointC = Math.min(nearestDistanceFromPointC, distance);
+
+    if (nearestDistanceFromPointC === distance) {
+      snappablePositionFromPointC = position;
+    }
+  });
+
+  const nearestSnappablePosition = Math.min(
+    nearestDistanceFromPointA,
+    nearestDistanceFromPointB,
+    nearestDistanceFromPointC
+  );
+
+  if (nearestSnappablePosition === nearestDistanceFromPointA)
+    return snappablePositionFromPointA;
+
+  if (nearestSnappablePosition === nearestDistanceFromPointB)
+    return snappablePositionFromPointB;
+
+  if (nearestSnappablePosition === nearestDistanceFromPointC)
+    return snappablePositionFromPointC;
 }
 export default computeSnapPosition;


### PR DESCRIPTION
도형을 드래그 할 때 주위에 다른 도형이 가까이 있으면 자석처럼 붙는 Snap 기능을 추가했다.

초기에 설계할 당시에는 각 캔버스마다 `xAxisSnap` `yAxisSnap` 이라는 배열을 갖도록 하고, 여기서 스냅이 걸릴 좌표 값을 모두 관리하도록 만들 계획이었다.

하지만 그렇게 작업을 해보니 캔버스의 `children` 을 순회하면서 현재 캔버스 위에 그려진 도형의 좌표값을 받아오는 것이 훨씬 효율적이라는 것을 깨달았고, 그렇게 구현하도록 진행 방향을 바꿨다. (한 10 시간은 낭비한 것 같다...)