### PR TITLE
텍스트 입력과 Keydown 이벤트가 충돌하는 문제 수정

### DIFF
--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -7,6 +7,8 @@ import { changeCanvasName } from "../../../features/canvas/canvasSlice";
 import {
   selectCurrentWorkingCanvasIndex,
   selectSelectedShapeIndexes,
+  setInputFieldBlurred,
+  setInputFieldFocused,
 } from "../../../features/utility/utilitySlice";
 import useDragCanvas from "../../../hooks/useDragCanvas";
 import useDrawShape from "../../../hooks/useDrawShape";
@@ -45,8 +47,10 @@ function Canvas({ canvasIndex, ...canvas }) {
           }}
           defaultValue={canvas.canvasName}
           autoFocus
+          onFocus={() => dispatch(setInputFieldFocused())}
           onBlur={() => {
             setIsDoubleClicked(false);
+            dispatch(setInputFieldBlurred());
             dispatch(
               changeCanvasName({ name: inputRef.current.value, canvasIndex })
             );

--- a/src/components/atoms/ColorPicker/index.js
+++ b/src/components/atoms/ColorPicker/index.js
@@ -4,6 +4,10 @@ import {
   selectGlobalColor,
   setGlobalColor,
 } from "../../../features/globalStyles/globalStylesSlice";
+import {
+  setInputFieldBlurred,
+  setInputFieldFocused,
+} from "../../../features/utility/utilitySlice";
 import styles from "./ColorPicker.module.scss";
 
 function ColorPicker() {
@@ -16,9 +20,11 @@ function ColorPicker() {
         type="color"
         className={styles.picker}
         value={globalColor}
+        onFocus={() => dispatch(setInputFieldFocused())}
         onChange={(e) => {
           dispatch(setGlobalColor(e.target.value));
         }}
+        onBlur={() => dispatch(setInputFieldBlurred())}
       />
       <span>{globalColor}</span>
     </div>

--- a/src/components/atoms/FigureInput/index.js
+++ b/src/components/atoms/FigureInput/index.js
@@ -7,7 +7,10 @@ import {
 import {
   selectCurrentWorkingCanvasIndex,
   selectSelectedShapeIndexes,
+  setInputFieldFocused,
+  setInputFieldBlurred,
 } from "../../../features/utility/utilitySlice";
+// import { setIsInputFieldFocused } from "../../../features/utility/utilitySlice";
 import styles from "./FigureInput.module.scss";
 
 function FigureInput({ figure }) {
@@ -66,11 +69,13 @@ function FigureInput({ figure }) {
         name={figure}
         className={styles.input}
         value={value}
+        onFocus={() => dispatch(setInputFieldFocused())}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
           e.key === "Enter" && e.target.blur();
         }}
         onBlur={() => {
+          dispatch(setInputFieldBlurred());
           dispatch(
             modifyShape({
               [style]: Number(value),

--- a/src/components/atoms/FontSizeInputField/index.js
+++ b/src/components/atoms/FontSizeInputField/index.js
@@ -1,9 +1,14 @@
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+
 import {
   selectGlobalFontSize,
   setGlobalFontSize,
 } from "../../../features/globalStyles/globalStylesSlice";
+import {
+  setInputFieldBlurred,
+  setInputFieldFocused,
+} from "../../../features/utility/utilitySlice";
 import styles from "./FontSizeInputField.module.scss";
 
 function FontSizeInputField() {
@@ -17,12 +22,14 @@ function FontSizeInputField() {
       type="number"
       className={styles.input}
       value={value}
+      onFocus={() => dispatch(setInputFieldFocused())}
       onChange={(e) => setValue(e.target.value)}
       onKeyDown={(e) => {
         e.key === "Enter" && e.target.blur();
       }}
       onBlur={() => {
         dispatch(setGlobalFontSize(Number(value)));
+        dispatch(setInputFieldBlurred());
       }}
     />
   );

--- a/src/components/atoms/ProjectTitleInput/index.js
+++ b/src/components/atoms/ProjectTitleInput/index.js
@@ -3,6 +3,8 @@ import { useDispatch, useSelector } from "react-redux";
 
 import {
   selectProjectTitle,
+  setInputFieldBlurred,
+  setInputFieldFocused,
   setProjectTitle,
 } from "../../../features/utility/utilitySlice";
 import styles from "./ProjectTitleInput.module.scss";
@@ -21,9 +23,11 @@ function ProjectTitleInput() {
         type="text"
         className={styles.field}
         value={title}
+        onFocus={() => dispatch(setInputFieldFocused())}
         onChange={(e) => setTitle(e.target.value)}
         onBlur={() => {
           dispatch(setProjectTitle(title));
+          dispatch(setInputFieldBlurred());
           setIsFocused(false);
         }}
         autoFocus

--- a/src/components/atoms/ShapeText/index.js
+++ b/src/components/atoms/ShapeText/index.js
@@ -56,6 +56,11 @@ function ShapeText({
     setIsMouseHovered(false);
   }, [canvasIndex, currentShapeIndex, shapeIndex, currentCanvasIndex]);
 
+  useEffect(() => {
+    if (!inputRef.current) return;
+    inputRef.current.focus();
+  }, [inputRef, isDoubleClicked]);
+
   if (isDoubleClicked)
     return (
       <form>
@@ -70,6 +75,7 @@ function ShapeText({
           }}
           contentEditable="plaintext-only"
           suppressContentEditableWarning
+          spellCheck={false}
           onBlur={(e) => {
             const newText = {
               text: inputRef.current.textContent,

--- a/src/components/atoms/ThicknessInputField/index.js
+++ b/src/components/atoms/ThicknessInputField/index.js
@@ -4,6 +4,10 @@ import {
   selectGlobalThickness,
   setGlobalThickness,
 } from "../../../features/globalStyles/globalStylesSlice";
+import {
+  setInputFieldBlurred,
+  setInputFieldFocused,
+} from "../../../features/utility/utilitySlice";
 import styles from "./ThicknessInputField.module.scss";
 
 function ThicknessInputField() {
@@ -17,12 +21,14 @@ function ThicknessInputField() {
       type="number"
       className={styles.input}
       value={value}
+      onFocus={() => dispatch(setInputFieldFocused())}
       onChange={(e) => setValue(e.target.value)}
       onKeyDown={(e) => {
         e.key === "Enter" && e.target.blur();
       }}
       onBlur={() => {
         dispatch(setGlobalThickness(Number(value)));
+        dispatch(setInputFieldBlurred());
       }}
     />
   );

--- a/src/hooks/useDragToScroll.js
+++ b/src/hooks/useDragToScroll.js
@@ -1,16 +1,18 @@
 import { useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import {
   finishDragScroll,
+  selectIsInputFieldFocused,
   startDragScoll,
 } from "../features/utility/utilitySlice";
 
 function useDragToScroll(boardRef) {
   const dispatch = useDispatch();
+  const isInputFieldFocused = useSelector(selectIsInputFieldFocused);
 
   useEffect(() => {
-    if (!boardRef.current) return;
+    if (!boardRef.current || isInputFieldFocused) return;
 
     const board = boardRef.current;
 
@@ -49,7 +51,7 @@ function useDragToScroll(boardRef) {
         dispatch(startDragScoll());
         board.style.cursor = "grab";
         board.addEventListener("mousedown", handleMouseDown);
-        document.addEventListener("keyup", handleSpaceKeyUp);
+        window.addEventListener("keyup", handleSpaceKeyUp);
       }
     };
 
@@ -59,14 +61,14 @@ function useDragToScroll(boardRef) {
         dispatch(finishDragScroll());
         board.style.cursor = "default";
         board.removeEventListener("mousedown", handleMouseDown);
-        document.removeEventListener("keyup", handleSpaceKeyUp);
+        window.removeEventListener("keyup", handleSpaceKeyUp);
       }
     };
 
-    document.addEventListener("keydown", handleSpaceKeyDown);
+    window.addEventListener("keydown", handleSpaceKeyDown);
 
-    return () => document.removeEventListener("keydown", handleSpaceKeyDown);
-  }, [boardRef, dispatch]);
+    return () => window.removeEventListener("keydown", handleSpaceKeyDown);
+  }, [boardRef, dispatch, isInputFieldFocused]);
 }
 
 export default useDragToScroll;

--- a/src/hooks/useDrawShape.js
+++ b/src/hooks/useDrawShape.js
@@ -295,6 +295,7 @@ function useDrawShape(elementRef, canvasIndex, shapes) {
     };
 
     const handleClickText = (e) => {
+      e.stopPropagation();
       const form = document.createElement("form");
       const previewText = document.createElement("div");
       const elementFigures = element.getBoundingClientRect();
@@ -308,6 +309,8 @@ function useDrawShape(elementRef, canvasIndex, shapes) {
       previewText.style.left = startLeft + "px";
       previewText.style.position = "absolute";
       previewText.style.fontSize = globalFontSize + "px";
+      previewText.style.color = globalColor;
+      previewText.style.caretColor = "green";
       previewText.style.backgroundColor = "transparent";
       previewText.style.margin = 0;
       previewText.style.padding = 0;
@@ -319,6 +322,9 @@ function useDrawShape(elementRef, canvasIndex, shapes) {
       element.appendChild(form);
 
       previewText.style.top = startTop - previewText.clientHeight + "px";
+      window.onload = () => {
+        console.log("hi");
+      };
 
       dispatch(setInputFieldFocused());
       dispatch(setCurrentTool(tools.SELECTOR));

--- a/src/hooks/useGlobalKeyboardShortCut.js
+++ b/src/hooks/useGlobalKeyboardShortCut.js
@@ -7,6 +7,7 @@ import { deleteShape } from "../features/canvas/canvasSlice";
 import {
   emptySelectedShapeIndexes,
   selectCurrentWorkingCanvasIndex,
+  selectIsInputFieldFocused,
   selectSelectedShapeIndexes,
   setCurrentTool,
 } from "../features/utility/utilitySlice";
@@ -16,8 +17,11 @@ function useGlobalKeyboardShortCut() {
 
   const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
   const selectedShapeIndexes = useSelector(selectSelectedShapeIndexes);
+  const isInputFieldFocused = useSelector(selectIsInputFieldFocused);
 
   useEffect(() => {
+    if (isInputFieldFocused) return;
+
     const deleteShapeShortCut = (e) => {
       if (e.key === "Backspace" && selectedShapeIndexes.length) {
         e.preventDefault();
@@ -119,7 +123,7 @@ function useGlobalKeyboardShortCut() {
       window.removeEventListener("keydown", textToolShortCut);
       window.removeEventListener("keydown", canvasToolShortCut);
     };
-  }, [dispatch, selectedShapeIndexes, workingCanvasIndex]);
+  }, [dispatch, isInputFieldFocused, selectedShapeIndexes, workingCanvasIndex]);
 }
 
 export default useGlobalKeyboardShortCut;

--- a/src/hooks/useMockZoom.js
+++ b/src/hooks/useMockZoom.js
@@ -3,17 +3,19 @@ import { useDispatch, useSelector } from "react-redux";
 
 import {
   selectCurrentScale,
+  selectIsInputFieldFocused,
   setCurrentScale,
 } from "../features/utility/utilitySlice";
 import { computeMockZoom } from "../utilities/computeMockZoom";
 
 function useMockZoom(outerRef, innerRef) {
   const currentScale = useSelector(selectCurrentScale);
+  const isInputFieldFocused = useSelector(selectIsInputFieldFocused);
 
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!innerRef.current || !outerRef.current) return;
+    if (!innerRef.current || !outerRef.current || isInputFieldFocused) return;
 
     const outerBoard = outerRef.current;
     const innerBoard = innerRef.current;
@@ -69,7 +71,7 @@ function useMockZoom(outerRef, innerRef) {
       window.removeEventListener("keydown", zoomWithKeyboard);
       window.removeEventListener("wheel", zoomWithWheel);
     };
-  }, [currentScale, dispatch, innerRef, outerRef]);
+  }, [currentScale, dispatch, innerRef, isInputFieldFocused, outerRef]);
 }
 
 export default useMockZoom;


### PR DESCRIPTION
단축키를 담당하는 로직과 텍스트 입력을 담당하는 로직이 충돌해서 띄어쓰기가 안된다거나, 글자를 지우려고 백스페이스를 누르면 도형이 지워지는 등의 문제가 발생했다. 해당 문제가 더는 발생하지 않도록 스토어에 `isInputFieldFocused` 라는 속성을 추가해서 텍스트를 입력중일 때는 이벤트 핸들러를 중지하도록 처리했다.