### PR TITLE
Edit Mode 에서 드래그로 크기 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,10 @@
     "jsx-a11y/no-static-element-interactions": 0,
     "jsx-a11y/no-noninteractive-element-interactions": 0,
     "jsx-a11y/no-autofocus": 0
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack-dev-server",
     "build": "NODE_ENV=production webpack --mode production --progress",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "lint": "./node_modules/.bin/eslint src standard --verbose"
   },
   "author": "intaek h",
   "license": "ISC",

--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -92,7 +92,7 @@ function Canvas({ canvasIndex, ...canvas }) {
           )
         )}
         {workingCanvasIndex === canvasIndex && selectedShapeIndexes.length
-          ? directions.map((direction) => (
+          ? Object.values(directions).map((direction) => (
               <EditPointer
                 direction={direction}
                 key={direction}

--- a/src/components/atoms/FigureInput/index.js
+++ b/src/components/atoms/FigureInput/index.js
@@ -10,7 +10,7 @@ import {
   setInputFieldFocused,
   setInputFieldBlurred,
 } from "../../../features/utility/utilitySlice";
-// import { setIsInputFieldFocused } from "../../../features/utility/utilitySlice";
+import translateFigure from "../../../utilities/translateFigure";
 import styles from "./FigureInput.module.scss";
 
 function FigureInput({ figure }) {
@@ -90,18 +90,3 @@ function FigureInput({ figure }) {
 }
 
 export default FigureInput;
-
-function translateFigure(figure) {
-  switch (figure) {
-    case "X":
-      return "left";
-    case "Y":
-      return "top";
-    case "W":
-      return "width";
-    case "H":
-      return "height";
-    default:
-      return;
-  }
-}

--- a/src/features/canvas/canvasSlice.js
+++ b/src/features/canvas/canvasSlice.js
@@ -109,6 +109,90 @@ const canvasSlice = createSlice({
         ...payload,
       };
     },
+    resizeNorth: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].top =
+          current(state[canvasIndex].children[i]).top + payload.change;
+        state[canvasIndex].children[i].height =
+          current(state[canvasIndex].children[i]).height - payload.change;
+      });
+    },
+    resizeEast: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].width =
+          current(state[canvasIndex].children[i]).width + payload.change;
+      });
+    },
+    resizeSouth: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].height =
+          current(state[canvasIndex].children[i]).height + payload.change;
+      });
+    },
+    resizeWest: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].left =
+          current(state[canvasIndex].children[i]).left + payload.change;
+        state[canvasIndex].children[i].width =
+          current(state[canvasIndex].children[i]).width - payload.change;
+      });
+    },
+    resizeNorthEast: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].top =
+          current(state[canvasIndex].children[i]).top + payload.verChange;
+        state[canvasIndex].children[i].height =
+          current(state[canvasIndex].children[i]).height - payload.verChange;
+        state[canvasIndex].children[i].width =
+          current(state[canvasIndex].children[i]).width + payload.horChange;
+      });
+    },
+    resizeSouthEast: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].height =
+          current(state[canvasIndex].children[i]).height + payload.verChange;
+        state[canvasIndex].children[i].width =
+          current(state[canvasIndex].children[i]).width + payload.horChange;
+      });
+    },
+    resizeNorthWest: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].top =
+          current(state[canvasIndex].children[i]).top + payload.verChange;
+        state[canvasIndex].children[i].height =
+          current(state[canvasIndex].children[i]).height - payload.verChange;
+        state[canvasIndex].children[i].left =
+          current(state[canvasIndex].children[i]).left + payload.horChange;
+        state[canvasIndex].children[i].width =
+          current(state[canvasIndex].children[i]).width - payload.horChange;
+      });
+    },
+    resizeSouthWest: (state, { payload }) => {
+      const canvasIndex = payload.canvasIndex;
+      const shapeIndexes = payload.shapeIndexes;
+      shapeIndexes.forEach((i) => {
+        state[canvasIndex].children[i].left =
+          current(state[canvasIndex].children[i]).left + payload.horChange;
+        state[canvasIndex].children[i].width =
+          current(state[canvasIndex].children[i]).width - payload.horChange;
+        state[canvasIndex].children[i].height =
+          current(state[canvasIndex].children[i]).height + payload.verChange;
+      });
+    },
     changeShapeIndex: (state, { payload: { canvasIdx, fromIdx, toIdx } }) => {
       const shape = state[canvasIdx].children[fromIdx];
       state[canvasIdx].children.splice(fromIdx, 1);
@@ -135,6 +219,14 @@ export const {
   changeShapeColor,
   changeTextProperty,
   changeLineThickness,
+  resizeEast,
+  resizeNorth,
+  resizeSouth,
+  resizeWest,
+  resizeNorthEast,
+  resizeSouthEast,
+  resizeNorthWest,
+  resizeSouthWest,
 } = canvasSlice.actions;
 
 export default canvasSlice.reducer;

--- a/src/hooks/useDrawShape.js
+++ b/src/hooks/useDrawShape.js
@@ -41,6 +41,7 @@ function useDrawShape(elementRef, canvasIndex, shapes) {
     const element = elementRef.current;
 
     const handleMouseDownSelector = (e) => {
+      e.stopPropagation();
       const previewShape = document.createElement("div");
       const elementFigures = element.getBoundingClientRect();
       const elementTop = elementFigures.top;

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,16 +1,22 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import undoable from "redux-undo";
-import canvasSlice from "../features/canvas/canvasSlice";
 
+import canvasSlice from "../features/canvas/canvasSlice";
 import globalStylesSlice from "../features/globalStyles/globalStylesSlice";
 import utilitySlice from "../features/utility/utilitySlice";
+import { batchGroupBy } from "../utilities/batchActions";
+
+const MAXIMUM_UNDO_COUNT = 100;
 
 const workbench = combineReducers({
   globalStyles: globalStylesSlice,
   canvas: canvasSlice,
 });
 
-const undoableWorkBench = undoable(workbench);
+const undoableWorkBench = undoable(workbench, {
+  groupBy: batchGroupBy.init(),
+  limit: MAXIMUM_UNDO_COUNT,
+});
 
 const store = configureStore({
   reducer: {

--- a/src/utilities/batchActions.js
+++ b/src/utilities/batchActions.js
@@ -1,0 +1,19 @@
+import { groupByActionTypes } from "redux-undo";
+
+export const batchGroupBy = {
+  _group: null,
+
+  start(group) {
+    this._group = group;
+  },
+
+  end() {
+    this._group = null;
+  },
+
+  init(rawActions) {
+    const defaultGroupBy = groupByActionTypes(rawActions);
+
+    return (action) => this._group || defaultGroupBy(action);
+  },
+};

--- a/src/utilities/computeSelectionBox.js
+++ b/src/utilities/computeSelectionBox.js
@@ -6,12 +6,12 @@ function computeSelectionBox(shapes, selectedIdxArr) {
     width: Number.MIN_SAFE_INTEGER,
   };
 
-  shapes.forEach((obj, i) => {
+  shapes.forEach((shape, i) => {
     if (selectedIdxArr.includes(i)) {
-      result.top = Math.min(result.top, obj.top);
-      result.left = Math.min(result.left, obj.left);
-      result.height = Math.max(result.height, obj.height + obj.top);
-      result.width = Math.max(result.width, obj.width + obj.left);
+      result.top = Math.min(result.top, shape.top);
+      result.left = Math.min(result.left, shape.left);
+      result.height = Math.max(result.height, shape.height + shape.top);
+      result.width = Math.max(result.width, shape.width + shape.left);
     }
   });
 

--- a/src/utilities/translateFigure.js
+++ b/src/utilities/translateFigure.js
@@ -1,0 +1,16 @@
+function translateFigure(figure) {
+  switch (figure) {
+    case "X":
+      return "left";
+    case "Y":
+      return "top";
+    case "W":
+      return "width";
+    case "H":
+      return "height";
+    default:
+      return;
+  }
+}
+
+export default translateFigure;


### PR DESCRIPTION
캔버스에 그려진 도형을 한 번 클릭하면 해당 도형이 Edit Mode 로 변한다. 도형 주위에 8 개의 점이 생기며, 점을 드래그 하면 드래그 한 만큼 도형의 크기가 변한다. 만약 여러개의 도형을 선택한 다음 점을 드래그 한다면 선택된 모든 도형의 크기가 같은 비율로 변한다.

mousemove 이벤트에서 선택된 도형과 똑같은 가상의 도형을 생성해서 원하는 만큼 가상의 도형을 변형하고, mouseup 이벤트에 dispatch 를 날리도록 하고 싶었으나, 도형이 여러개일 때 (혹은 글자가 섞여있을 때) 작업 복잡도가 너무 높아진다고 판단했다.

그래서 mousemove 이벤트에 실시간으로 dispatch 를 날려서 선택된 도형을 변형하는 방법으로 작업했다. 문제점은, 한번 드래그 할 때 마다 dispatch 가 수십개를 날리게 되면서 UNDO/REDO 기능이 방해받는다. 이 문제를 해결하기 위해 mousemove 시에 생긴 모든 dispatch 를 batch 하는 코드를 짜서 UNDO 가 정상적으로 동작하도록 했다.