### PR TITLE
CSS 연산 많은 로직에 requestAnimationFrame 적용

### DIFF
--- a/src/hooks/useDragCanvas.js
+++ b/src/hooks/useDragCanvas.js
@@ -23,6 +23,7 @@ function useDragCanvas(
 
     let movedTop;
     let movedLeft;
+    let lastAnimationFrame;
 
     const handleMouseDown = (e) => {
       const originalElPositionTop = e.currentTarget.offsetTop;
@@ -36,6 +37,15 @@ function useDragCanvas(
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
+        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
+
+        lastAnimationFrame = requestAnimationFrame(() => {
+          renderNextAnimationFrame();
+          lastAnimationFrame = null;
+        });
+      };
+
+      const renderNextAnimationFrame = () => {
         canvasName.style.transform = `translate(${movedLeft}px, calc(${movedTop}px - 100%))`;
         canvas.style.transform = `translate(${movedLeft}px, ${movedTop}px)`;
       };

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -98,6 +98,7 @@ function useDragShape(
       let isHorMidAttached = false;
       let nearestPossibleSnapAtX;
       let nearestPossibleSnapAtY;
+      let lastAnimationFrame;
 
       canvas.appendChild(verticalLine);
       canvas.appendChild(horizontalLine);
@@ -106,6 +107,15 @@ function useDragShape(
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
+        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
+
+        lastAnimationFrame = requestAnimationFrame(() => {
+          renderNextAnimationFrame();
+          lastAnimationFrame = null;
+        });
+      };
+
+      const renderNextAnimationFrame = () => {
         const currentLeft = originalElPositionLeft + movedLeft;
         const currentTop = originalElPositionTop + movedTop;
 

--- a/src/hooks/useDragToResize.js
+++ b/src/hooks/useDragToResize.js
@@ -42,6 +42,7 @@ function useDragToResize(pointerRef, direction) {
       let movedLeft;
       let prevMovedTop = 0;
       let prevMovedLeft = 0;
+      let lastAnimationFrame;
 
       batchGroupBy.start(randomID);
 
@@ -49,6 +50,17 @@ function useDragToResize(pointerRef, direction) {
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
+        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
+
+        lastAnimationFrame = requestAnimationFrame(() => {
+          renderNextAnimationFrame();
+          lastAnimationFrame = null;
+          prevMovedTop = movedTop;
+          prevMovedLeft = movedLeft;
+        });
+      };
+
+      const renderNextAnimationFrame = () => {
         if (direction === directions.N) {
           dispatch(
             resizeNorth({
@@ -118,9 +130,6 @@ function useDragToResize(pointerRef, direction) {
             })
           );
         }
-
-        prevMovedTop = movedTop;
-        prevMovedLeft = movedLeft;
       };
 
       const handleMouseUp = () => {

--- a/src/hooks/useDrawCanvas.js
+++ b/src/hooks/useDrawCanvas.js
@@ -48,6 +48,8 @@ function useDrawCanvas(elementRef) {
       element.appendChild(canvasPreview);
       element.appendChild(sizePreview);
 
+      let lastAnimationFrame;
+
       const handleMouseMove = (e) => {
         const { height, left, top, width } = computePreviewElement(
           { x: startLeft, y: startTop },
@@ -57,6 +59,15 @@ function useDrawCanvas(elementRef) {
           }
         );
 
+        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
+
+        lastAnimationFrame = requestAnimationFrame(() => {
+          renderNextAnimationFrame(height, left, top, width)();
+          lastAnimationFrame = null;
+        });
+      };
+
+      const renderNextAnimationFrame = (height, left, top, width) => () => {
         canvasPreview.style.height = height + "px";
         canvasPreview.style.width = width + "px";
         canvasPreview.style.top = top + "px";

--- a/src/hooks/useMockZoom.js
+++ b/src/hooks/useMockZoom.js
@@ -19,6 +19,7 @@ function useMockZoom(outerRef, innerRef) {
 
     const outerBoard = outerRef.current;
     const innerBoard = innerRef.current;
+    let lastAnimationFrame;
 
     const zoomWithKeyboard = (event) => {
       if (
@@ -55,12 +56,21 @@ function useMockZoom(outerRef, innerRef) {
           currentScale
         );
 
-        innerBoard.style.transform = `scale(${scale}, ${scale})`;
-        outerBoard.scrollTop = adjustedScroll.y;
-        outerBoard.scrollLeft = adjustedScroll.x;
+        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
 
-        dispatch(setCurrentScale(scale));
+        lastAnimationFrame = requestAnimationFrame(() => {
+          renderNextAnimationFrame(adjustedScroll, scale)();
+          lastAnimationFrame = null;
+        });
       }
+    };
+
+    const renderNextAnimationFrame = (adjustedScroll, scale) => () => {
+      innerBoard.style.transform = `scale(${scale}, ${scale})`;
+      outerBoard.scrollTop = adjustedScroll.y;
+      outerBoard.scrollLeft = adjustedScroll.x;
+
+      dispatch(setCurrentScale(scale));
     };
 
     innerRef.current.style.transform = `scale(${currentScale}, ${currentScale})`;


### PR DESCRIPTION

드래그와 스크롤 처럼 mousemove 에 실행되는 이벤트는 굉장히 빠른 스타일 연산이 요구된다. 만약 16ms 안에 모든 연산 및 페인팅을 끝내지 못할 경우 유저는 프레임 드랍을 느끼게 된다. 이 때 사용되는 API 가 `requestAnimationFrame` 이다. 이를 통해 최대한 16ms 내에 연산을 마치도록 요구할 수 있다. 물론 연산이 너무 많다면 16ms 를 넘기게 되지만 사용하기 전 보다 균일한 프레임을 확인할 수 있다. 
figmaJSX 에서도 도형이 많아지면 연산이 힘들 것 같은 hook 을 대상으로 `requestAnimationFrame` 을 적용했다. 아래의 사진은 그 전후를 비교한 performance graph 이다.

### RAF 없이 도형 한 개 리사이징
![RAF 없이 도형 한 개 리사이징](https://user-images.githubusercontent.com/108341074/177780825-22e1e903-650b-408a-a3be-1bd62c7edd68.jpeg)

### RAF 로 도형 한 개 리사이징
![RAF 로 도형 한 개 리사이징](https://user-images.githubusercontent.com/108341074/177781045-3d4424fc-7d0a-44d7-8996-90e8beff5dce.jpeg)

### RAF 없이 도형 100 개 리사이징
![RAF 없이 도형 100 개 리사이징](https://user-images.githubusercontent.com/108341074/177781134-6b729228-4a8e-4d1d-aaf8-e1e9689126a0.jpeg)

### RAF 로 도형 100 개 리사이징 16 보다 높지만 시간이 균일함
![RAF 로 도형 100 개 리사이징 16 보다 높지만 시간이 균일함](https://user-images.githubusercontent.com/108341074/177781219-2d7f8200-8eec-46c7-aacf-29af65fc55e2.jpeg)

[requestAnimationFrame 을 선택적으로 적용한 이유](https://stackoverflow.com/a/37449190/16469108)

