### PR TITLE
드래그 중에 편집점 숨기기

### DIFF
--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -6,6 +6,7 @@ import tools from "../../../constants/tools";
 import { changeCanvasName } from "../../../features/canvas/canvasSlice";
 import {
   selectCurrentWorkingCanvasIndex,
+  selectIsDraggingShape,
   selectSelectedShapeIndexes,
   setInputFieldBlurred,
   setInputFieldFocused,
@@ -23,6 +24,7 @@ function Canvas({ canvasIndex, ...canvas }) {
 
   const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
   const selectedShapeIndexes = useSelector(selectSelectedShapeIndexes);
+  const isDraggingShape = useSelector(selectIsDraggingShape);
 
   const canvasRef = useRef();
   const inputRef = useRef();
@@ -91,7 +93,9 @@ function Canvas({ canvasIndex, ...canvas }) {
             />
           )
         )}
-        {workingCanvasIndex === canvasIndex && selectedShapeIndexes.length
+        {workingCanvasIndex === canvasIndex &&
+        selectedShapeIndexes.length &&
+        !isDraggingShape
           ? Object.values(directions).map((direction) => (
               <EditPointer
                 direction={direction}

--- a/src/features/utility/utilitySlice.js
+++ b/src/features/utility/utilitySlice.js
@@ -6,6 +6,7 @@ const initialState = {
   projectTitle: "untitled_project",
   isSelectorActivated: true,
   isDragScrolling: false,
+  isDraggingShape: false,
   isInputFieldFocused: false,
   workingCanvasIndex: 0,
   selectedShapeIndexes: [],
@@ -54,6 +55,12 @@ const utilitySlice = createSlice({
     finishDragScroll: (state) => {
       state.isDragScrolling = false;
     },
+    startDraggingShape: (state) => {
+      state.isDraggingShape = true;
+    },
+    finishDraggingShape: (state) => {
+      state.isDraggingShape = false;
+    },
     setInputFieldFocused: (state) => {
       state.isInputFieldFocused = true;
     },
@@ -92,6 +99,8 @@ export const selectCurrentTool = (state) => state.utility.currentTool;
 
 export const selectIsDragScrolling = (state) => state.utility.isDragScrolling;
 
+export const selectIsDraggingShape = (state) => state.utility.isDraggingShape;
+
 export const selectHoveredShape = (state) => state.utility.hoveredShape;
 
 export const selectCurrentWorkingCanvasIndex = (state) =>
@@ -123,6 +132,8 @@ export const {
   replaceSelectedShapeIndexes,
   loadUtility,
   resetUtility,
+  finishDraggingShape,
+  startDraggingShape,
 } = utilitySlice.actions;
 
 export const utilitySliceName = utilitySlice.name;

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -12,9 +12,11 @@ import {
   selectAllCanvas,
 } from "../features/canvas/canvasSlice";
 import {
+  finishDraggingShape,
   selectCurrentScale,
   selectCurrentTool,
   selectIsDragScrolling,
+  startDraggingShape,
 } from "../features/utility/utilitySlice";
 import computeSnapPosition from "../utilities/computeSnapPosition";
 
@@ -105,11 +107,17 @@ function useDragShape(
       let nearestPossibleSnapAtX;
       let nearestPossibleSnapAtY;
       let lastAnimationFrame;
+      let isFirstMove = true;
 
       canvas.appendChild(verticalLine);
       canvas.appendChild(horizontalLine);
 
       const handleMouseMove = (e) => {
+        if (isFirstMove) {
+          dispatch(startDraggingShape());
+          isFirstMove = false;
+        }
+
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
@@ -381,6 +389,8 @@ function useDragShape(
             );
           }
         }
+
+        dispatch(finishDraggingShape());
 
         movedTop = 0;
         movedLeft = 0;


### PR DESCRIPTION
도형을 드래그 할 때는 편집점을 숨기도록 수정했다.

이유: 드래그하면 도형의 원래 위치에 편집점이 남아있었기 때문에 그냥 숨기기로 했다. 도형을 움직이는건 비제어, 편집점의 위치는 제어되기 때문에.