### PR TITLE
색상 변경 액션 Batching

### DIFF
--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,7 +1,7 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import undoable from "redux-undo";
 
-import canvasSlice from "../features/canvas/canvasSlice";
+import canvasSlice, { changeShapeColor } from "../features/canvas/canvasSlice";
 import globalStylesSlice from "../features/globalStyles/globalStylesSlice";
 import utilitySlice from "../features/utility/utilitySlice";
 import { batchGroupBy } from "../utilities/batchActions";
@@ -15,7 +15,7 @@ const workbench = combineReducers({
 });
 
 const undoableWorkBench = undoable(workbench, {
-  groupBy: batchGroupBy.init(),
+  groupBy: batchGroupBy.init(changeShapeColor.type),
   limit: MAXIMUM_UNDO_COUNT,
 });
 


### PR DESCRIPTION
Undo/Redo 기능을 위해서 선택된 도형의 색상을 변경하는 연속적인 액션을 Batching 했다. Color Picker 에서 색상을 드래그 하면 mousemove 이벤트로 수십개의 같은 액션이 dispatch 되기 때문에 Batching 을 안하면 뒤로가기 기능이 상식적으로 작동하지 않게 된다.