### PR TITLE
도형 드래그에 requestAnimationFrame 제거

### DIFF
--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -106,7 +106,6 @@ function useDragShape(
       let isHorMidAttached = false;
       let nearestPossibleSnapAtX;
       let nearestPossibleSnapAtY;
-      let lastAnimationFrame;
       let isFirstMove = true;
 
       canvas.appendChild(verticalLine);
@@ -121,15 +120,6 @@ function useDragShape(
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
-        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
-
-        lastAnimationFrame = requestAnimationFrame(() => {
-          renderNextAnimationFrame();
-          lastAnimationFrame = null;
-        });
-      };
-
-      const renderNextAnimationFrame = () => {
         const currentLeft = originalElPositionLeft + movedLeft;
         const currentTop = originalElPositionTop + movedTop;
 


### PR DESCRIPTION
도형을 드래그 해서 위치를 변경하는 로직에 requestAnimationFrame 을 적용했었는데, 이 때문에 정말 빠르게 도형을 드래그한 뒤에 mouseup 하면, 
1. 도형의 위치 값이 마지막 마우스 위치와 동일하게 스토어에 dispatch 되긴 한다.
2. 하지만 화면에 보이는 도형은 드래그 하기 전 위치로 돌아와있는 문제가 생겼다.

드래그의 마지막 위치 까지 도형이 끌려 갔다가 마우스를 놓으면 다시 원위치로 튕겨저 돌아가는 모습이었다. 스토어에 변경된 위치가 정확히 dispatch 되었는데도 불구하고 화면 상에서만 원래 위치에 남아있는 건 리액트의 문제가 아니라고 판단. requestAnimationFrame 때문에 미처 도형의 바뀐 위치를 계산하지 못하고 다음 프레임으로 넘어가 버린게 아닐까 하는 추측에 도형 드래그 로직에서 requestAnimationFrame 을 제거해 봤다.

그랬더니 잘 됐다!