### PR TITLE
백스페이스 키로 캔버스 삭제하기

### DIFF
--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -10,6 +10,7 @@ import {
   selectSelectedShapeIndexes,
   setInputFieldBlurred,
   setInputFieldFocused,
+  setWorkingCanvasIndex,
 } from "../../../features/utility/utilitySlice";
 import useDragCanvas from "../../../hooks/useDragCanvas";
 import useDrawShape from "../../../hooks/useDrawShape";
@@ -18,6 +19,7 @@ import ShapeText from "../ShapeText";
 import EditPointer from "../EditPointer";
 import cn from "./Canvas.module.scss";
 import computeSelectionBox from "../../../utilities/computeSelectionBox";
+import { CANVAS_NAME_STYLES } from "../../../constants/styles";
 
 function Canvas({ canvasIndex, ...canvas }) {
   const dispatch = useDispatch();
@@ -65,10 +67,14 @@ function Canvas({ canvasIndex, ...canvas }) {
           style={{
             top: canvas.top,
             left: canvas.left,
+            color:
+              workingCanvasIndex === canvasIndex &&
+              CANVAS_NAME_STYLES.HIGHLIGHTED_COLOR,
           }}
           onDoubleClick={() => {
             setIsDoubleClicked(true);
           }}
+          onClick={() => dispatch(setWorkingCanvasIndex(canvasIndex))}
         >
           {canvas.canvasName}
         </span>

--- a/src/constants/styles.js
+++ b/src/constants/styles.js
@@ -16,6 +16,7 @@ export const SHAPE_TEXT_STYLES = {
 
 export const CANVAS_NAME_STYLES = {
   OPACITY: 0.5,
+  HIGHLIGHTED_COLOR: "#5096ff",
 };
 
 export const VER_SNAP_LINE_STYLES = {

--- a/src/features/canvas/canvasSlice.js
+++ b/src/features/canvas/canvasSlice.js
@@ -26,6 +26,9 @@ const canvasSlice = createSlice({
       return payload;
     },
     resetCanvas: () => initialState,
+    deleteCanvas: (state, { payload: canvasIndex }) => {
+      state.splice(canvasIndex, 1);
+    },
     createCanvas: (state, { payload: { top, left, width, height } }) => {
       const newCanvas = {
         ...generateSampleCanvas(top, left, width, height),
@@ -212,6 +215,9 @@ const canvasSlice = createSlice({
 
 export const selectAllCanvas = (state) => state.workbench.present.canvas;
 
+export const selectCanvasLength = (state) =>
+  state.workbench.present.canvas.length;
+
 export const {
   createCanvas,
   changeCanvasName,
@@ -233,6 +239,7 @@ export const {
   resizeSouthWest,
   loadCanvas,
   resetCanvas,
+  deleteCanvas,
 } = canvasSlice.actions;
 
 export default canvasSlice.reducer;

--- a/src/hooks/useDrawCanvas.js
+++ b/src/hooks/useDrawCanvas.js
@@ -11,6 +11,7 @@ import {
   selectCurrentScale,
   selectCurrentTool,
   selectIsDragScrolling,
+  setCurrentTool,
 } from "../features/utility/utilitySlice";
 import computePreviewElement from "../utilities/computePreviewElement";
 
@@ -104,6 +105,8 @@ function useDrawCanvas(elementRef) {
 
         coordinates.height + coordinates.width > 4 &&
           dispatch(createCanvas(coordinates));
+
+        dispatch(setCurrentTool(tools.SELECTOR));
 
         canvasPreview.remove();
         sizePreview.remove();

--- a/src/hooks/useGlobalKeyboardShortCut.js
+++ b/src/hooks/useGlobalKeyboardShortCut.js
@@ -3,13 +3,18 @@ import { useDispatch, useSelector } from "react-redux";
 import { ActionCreators } from "redux-undo";
 
 import tools from "../constants/tools";
-import { deleteShape } from "../features/canvas/canvasSlice";
+import {
+  deleteCanvas,
+  deleteShape,
+  selectCanvasLength,
+} from "../features/canvas/canvasSlice";
 import {
   emptySelectedShapeIndexes,
   selectCurrentWorkingCanvasIndex,
   selectIsInputFieldFocused,
   selectSelectedShapeIndexes,
   setCurrentTool,
+  setWorkingCanvasIndex,
 } from "../features/utility/utilitySlice";
 
 function useGlobalKeyboardShortCut() {
@@ -18,6 +23,7 @@ function useGlobalKeyboardShortCut() {
   const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
   const selectedShapeIndexes = useSelector(selectSelectedShapeIndexes);
   const isInputFieldFocused = useSelector(selectIsInputFieldFocused);
+  const canvasCount = useSelector(selectCanvasLength);
 
   useEffect(() => {
     if (isInputFieldFocused) return;
@@ -32,6 +38,14 @@ function useGlobalKeyboardShortCut() {
             shapeIndexArr: selectedShapeIndexes,
           })
         );
+      } else if (
+        e.key === "Backspace" &&
+        selectedShapeIndexes.length === 0 &&
+        canvasCount > 1
+      ) {
+        e.preventDefault();
+        dispatch(deleteCanvas(workingCanvasIndex));
+        dispatch(setWorkingCanvasIndex(0));
       }
     };
 
@@ -137,7 +151,13 @@ function useGlobalKeyboardShortCut() {
       window.removeEventListener("keydown", textToolShortCut);
       window.removeEventListener("keydown", canvasToolShortCut);
     };
-  }, [dispatch, isInputFieldFocused, selectedShapeIndexes, workingCanvasIndex]);
+  }, [
+    canvasCount,
+    dispatch,
+    isInputFieldFocused,
+    selectedShapeIndexes,
+    workingCanvasIndex,
+  ]);
 }
 
 export default useGlobalKeyboardShortCut;


### PR DESCRIPTION
캔버스를 삭제하는 로직을 추가했다. 현재 작업중인 캔버스에서, 선택한 도형이 없을 때 백스페이스 키를 누르면 작업중인 캔버스가 삭제된다. 만약 아트보드에 캔버스가 딱 하나만 남았다면 캔버스를 삭제할 수 없다.