### PR TITLE
캔버스 드래그 스냅 기능

### DIFF
--- a/src/components/atoms/ArtBoard/index.js
+++ b/src/components/atoms/ArtBoard/index.js
@@ -56,7 +56,12 @@ function ArtBoard() {
     <div ref={boardRef} className={styles["artboard-wrapper"]}>
       <div ref={innerBoardRef} className={styles.artboard}>
         {canvases.map((canvas, i) => (
-          <Canvas {...canvas} canvasIndex={i} key={i} />
+          <Canvas
+            {...canvas}
+            canvasIndex={i}
+            artBoardRef={innerBoardRef}
+            key={i}
+          />
         ))}
       </div>
     </div>

--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -21,7 +21,7 @@ import cn from "./Canvas.module.scss";
 import computeSelectionBox from "../../../utilities/computeSelectionBox";
 import { CANVAS_NAME_STYLES } from "../../../constants/styles";
 
-function Canvas({ canvasIndex, ...canvas }) {
+function Canvas({ artBoardRef, canvasIndex, ...canvas }) {
   const dispatch = useDispatch();
 
   const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
@@ -36,7 +36,7 @@ function Canvas({ canvasIndex, ...canvas }) {
 
   useDrawShape(canvasRef, canvasIndex, canvas.children);
 
-  useDragCanvas(canvasRef, nameRef, canvasIndex, !isDoubleClicked);
+  useDragCanvas(canvasRef, nameRef, artBoardRef, canvasIndex, !isDoubleClicked);
 
   return (
     <>

--- a/src/hooks/useDragCanvas.js
+++ b/src/hooks/useDragCanvas.js
@@ -1,71 +1,280 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { CANVAS_NAME_STYLES } from "../constants/styles";
 
-import { modifyCanvas } from "../features/canvas/canvasSlice";
-import { selectCurrentScale } from "../features/utility/utilitySlice";
+import {
+  CANVAS_NAME_STYLES,
+  HOR_SNAP_LINE_STYLES,
+  VER_SNAP_LINE_STYLES,
+} from "../constants/styles";
+import { modifyCanvas, selectAllCanvas } from "../features/canvas/canvasSlice";
+import {
+  selectCurrentScale,
+  selectCurrentWorkingCanvasIndex,
+} from "../features/utility/utilitySlice";
+import computeSnapPosition from "../utilities/computeSnapPosition";
+
+const GRAVITY = 5;
 
 function useDragCanvas(
   canvasRef,
   canvasNameRef,
+  artBoardRef,
   canvasIndex,
   isRendered = true
 ) {
   const dispatch = useDispatch();
 
   const currentScale = useSelector(selectCurrentScale);
+  const canvases = useSelector(selectAllCanvas);
+  const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
 
   useEffect(() => {
-    if (!canvasNameRef.current || !canvasRef.current || !isRendered) return;
+    if (
+      !canvasNameRef.current ||
+      !canvasRef.current ||
+      !artBoardRef.current ||
+      !isRendered
+    )
+      return;
 
-    const canvasName = canvasNameRef.current;
+    const artBoard = artBoardRef.current;
     const canvas = canvasRef.current;
-
-    let movedTop;
-    let movedLeft;
-    let lastAnimationFrame;
+    const canvasName = canvasNameRef.current;
 
     const handleMouseDown = (e) => {
-      const originalElPositionTop = e.currentTarget.offsetTop;
-      const originalElPositionLeft = e.currentTarget.offsetLeft;
+      const verticalLine = document.createElement("div");
+      const horizontalLine = document.createElement("div");
+
+      const currentCanvasIndex =
+        Array.from(e.currentTarget.parentNode.childNodes).indexOf(
+          e.currentTarget
+        ) / 2;
+      const originalElPositionTop = e.currentTarget.nextSibling.offsetTop;
+      const originalElPositionLeft = e.currentTarget.nextSibling.offsetLeft;
+      const originalElHeight = e.currentTarget.nextSibling.offsetHeight;
+      const originalElWidth = e.currentTarget.nextSibling.offsetWidth;
       const originalMousePositionTop = e.clientY;
       const originalMousePositionLeft = e.clientX;
 
+      const canvasList = canvases.slice();
+      const filteredXAxisSnapPoints = [];
+      const filteredYAxisSnapPoints = [];
+
+      canvasList.splice(currentCanvasIndex, 1);
+
+      canvasList.forEach((canvas) => {
+        filteredXAxisSnapPoints.push(
+          canvas.left,
+          canvas.left + canvas.width / 2,
+          canvas.left + canvas.width
+        );
+        filteredYAxisSnapPoints.push(
+          canvas.top,
+          canvas.top + canvas.height / 2,
+          canvas.top + canvas.height
+        );
+      });
+
       canvasName.style.opacity = CANVAS_NAME_STYLES.OPACITY;
+
+      let movedTop;
+      let movedLeft;
+      let isLeftAttached = false;
+      let isRightAttached = false;
+      let isTopAttached = false;
+      let isBottomAttached = false;
+      let nearestPossibleSnapAtX;
+      let nearestPossibleSnapAtY;
+
+      artBoard.appendChild(verticalLine);
+      artBoard.appendChild(horizontalLine);
 
       const handleMouseMove = (e) => {
         movedTop = (e.clientY - originalMousePositionTop) / currentScale;
         movedLeft = (e.clientX - originalMousePositionLeft) / currentScale;
 
-        if (lastAnimationFrame) cancelAnimationFrame(lastAnimationFrame);
+        const currentLeft = originalElPositionLeft + movedLeft;
+        const currentTop = originalElPositionTop + movedTop;
 
-        lastAnimationFrame = requestAnimationFrame(() => {
-          renderNextAnimationFrame();
-          lastAnimationFrame = null;
-        });
-      };
+        canvasName.style.top = originalElPositionTop + movedTop + "px";
+        canvasName.style.left = originalElPositionLeft + movedLeft + "px";
 
-      const renderNextAnimationFrame = () => {
-        canvasName.style.transform = `translate(${movedLeft}px, calc(${movedTop}px - 100%))`;
-        canvas.style.transform = `translate(${movedLeft}px, ${movedTop}px)`;
+        verticalLine.style.visibility = VER_SNAP_LINE_STYLES.HIDDEN;
+        verticalLine.style.position = VER_SNAP_LINE_STYLES.POSITION;
+        verticalLine.style.width = VER_SNAP_LINE_STYLES.WIDTH;
+        verticalLine.style.height = VER_SNAP_LINE_STYLES.HEIGHT;
+        verticalLine.style.backgroundColor = VER_SNAP_LINE_STYLES.BG_COLOR;
+
+        horizontalLine.style.visibility = HOR_SNAP_LINE_STYLES.HIDDEN;
+        horizontalLine.style.position = HOR_SNAP_LINE_STYLES.POSITION;
+        horizontalLine.style.width = HOR_SNAP_LINE_STYLES.WIDTH;
+        horizontalLine.style.height = HOR_SNAP_LINE_STYLES.HEIGHT;
+        horizontalLine.style.backgroundColor = HOR_SNAP_LINE_STYLES.BG_COLOR;
+
+        nearestPossibleSnapAtX = computeSnapPosition(
+          filteredXAxisSnapPoints,
+          currentLeft,
+          currentLeft + originalElWidth,
+          currentLeft + originalElWidth / 2
+        );
+        nearestPossibleSnapAtY = computeSnapPosition(
+          filteredYAxisSnapPoints,
+          currentTop,
+          currentTop + originalElHeight,
+          currentTop + originalElHeight / 2
+        );
+
+        if (Math.abs(currentLeft - nearestPossibleSnapAtX) < GRAVITY) {
+          canvas.style.left = nearestPossibleSnapAtX + "px";
+          isLeftAttached = true;
+          isRightAttached = false;
+        } else if (
+          Math.abs(currentLeft + originalElWidth - nearestPossibleSnapAtX) <
+          GRAVITY
+        ) {
+          canvas.style.left = nearestPossibleSnapAtX - originalElWidth + "px";
+          isRightAttached = true;
+          isLeftAttached = false;
+        } else {
+          canvas.style.left = currentLeft + "px";
+          isLeftAttached = false;
+          isRightAttached = false;
+        }
+
+        if (Math.abs(currentTop - nearestPossibleSnapAtY) < GRAVITY) {
+          canvas.style.top = nearestPossibleSnapAtY + "px";
+          isTopAttached = true;
+          isBottomAttached = false;
+        } else if (
+          Math.abs(currentTop + originalElHeight - nearestPossibleSnapAtY) <
+          GRAVITY
+        ) {
+          canvas.style.top = nearestPossibleSnapAtY - originalElHeight + "px";
+          isBottomAttached = true;
+          isTopAttached = false;
+        } else {
+          canvas.style.top = currentTop + "px";
+          isTopAttached = false;
+          isBottomAttached = false;
+        }
+
+        if (isLeftAttached || isRightAttached) {
+          verticalLine.style.visibility = VER_SNAP_LINE_STYLES.VISIBLE;
+          verticalLine.style.left = nearestPossibleSnapAtX + "px";
+        }
+
+        if (isTopAttached || isBottomAttached) {
+          horizontalLine.style.visibility = VER_SNAP_LINE_STYLES.VISIBLE;
+          horizontalLine.style.top = nearestPossibleSnapAtY + "px";
+        }
       };
 
       const handleMouseUp = () => {
         const newShapeTop = originalElPositionTop + movedTop;
         const newShapeLeft = originalElPositionLeft + movedLeft;
 
-        canvasName.style.removeProperty("transform");
+        verticalLine.remove();
+        horizontalLine.remove();
         canvasName.style.removeProperty("opacity");
-        canvas.style.removeProperty("transform");
 
         if (movedTop || movedLeft) {
-          dispatch(
-            modifyCanvas({
-              top: newShapeTop,
-              left: newShapeLeft,
-              canvasIndex,
-            })
-          );
+          if (isLeftAttached && isTopAttached) {
+            dispatch(
+              modifyCanvas({
+                top: nearestPossibleSnapAtY,
+                left: nearestPossibleSnapAtX,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top = nearestPossibleSnapAtY + "px";
+            canvasName.style.left = nearestPossibleSnapAtX + "px";
+          } else if (isLeftAttached && isBottomAttached) {
+            dispatch(
+              modifyCanvas({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: nearestPossibleSnapAtX,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top =
+              nearestPossibleSnapAtY - originalElHeight + "px";
+            canvasName.style.left = nearestPossibleSnapAtX + "px";
+          } else if (isRightAttached && isTopAttached) {
+            dispatch(
+              modifyCanvas({
+                top: nearestPossibleSnapAtY,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top = nearestPossibleSnapAtY + "px";
+            canvasName.style.left =
+              nearestPossibleSnapAtX - originalElWidth + "px";
+          } else if (isRightAttached && isBottomAttached) {
+            dispatch(
+              modifyCanvas({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top =
+              nearestPossibleSnapAtY - originalElHeight + "px";
+            canvasName.style.left =
+              nearestPossibleSnapAtX - originalElWidth + "px";
+          } else if (isLeftAttached) {
+            dispatch(
+              modifyCanvas({
+                top: newShapeTop,
+                left: nearestPossibleSnapAtX,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top = newShapeTop + "px";
+            canvasName.style.left = nearestPossibleSnapAtX + "px";
+          } else if (isRightAttached) {
+            dispatch(
+              modifyCanvas({
+                top: newShapeTop,
+                left: nearestPossibleSnapAtX - originalElWidth,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top = newShapeTop + "px";
+            canvasName.style.left =
+              nearestPossibleSnapAtX - originalElWidth + "px";
+          } else if (isTopAttached) {
+            dispatch(
+              modifyCanvas({
+                top: nearestPossibleSnapAtY,
+                left: newShapeLeft,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top = nearestPossibleSnapAtY + "px";
+            canvasName.style.left = newShapeLeft + "px";
+          } else if (isBottomAttached) {
+            dispatch(
+              modifyCanvas({
+                top: nearestPossibleSnapAtY - originalElHeight,
+                left: newShapeLeft,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top =
+              nearestPossibleSnapAtY - originalElHeight + "px";
+            canvasName.style.left = newShapeLeft + "px";
+          } else {
+            dispatch(
+              modifyCanvas({
+                top: newShapeTop,
+                left: newShapeLeft,
+                canvasIndex,
+              })
+            );
+            canvasName.style.top = newShapeTop + "px";
+            canvasName.style.left = newShapeLeft + "px";
+          }
         }
 
         movedTop = 0;
@@ -80,7 +289,7 @@ function useDragCanvas(
 
     canvasName.addEventListener("mousedown", handleMouseDown);
 
-    return () => canvasName.removeEventListener("mouseDown", handleMouseDown);
+    return () => canvasName.removeEventListener("mousedown", handleMouseDown);
   }, [
     currentScale,
     dispatch,
@@ -88,6 +297,9 @@ function useDragCanvas(
     canvasNameRef,
     canvasRef,
     isRendered,
+    artBoardRef,
+    canvases,
+    workingCanvasIndex,
   ]);
 }
 

--- a/src/hooks/useDragCanvas.js
+++ b/src/hooks/useDragCanvas.js
@@ -63,16 +63,8 @@ function useDragCanvas(
       canvasList.splice(currentCanvasIndex, 1);
 
       canvasList.forEach((canvas) => {
-        filteredXAxisSnapPoints.push(
-          canvas.left,
-          canvas.left + canvas.width / 2,
-          canvas.left + canvas.width
-        );
-        filteredYAxisSnapPoints.push(
-          canvas.top,
-          canvas.top + canvas.height / 2,
-          canvas.top + canvas.height
-        );
+        filteredXAxisSnapPoints.push(canvas.left, canvas.left + canvas.width);
+        filteredYAxisSnapPoints.push(canvas.top, canvas.top + canvas.height);
       });
 
       canvasName.style.opacity = CANVAS_NAME_STYLES.OPACITY;

--- a/src/hooks/useDragShape.js
+++ b/src/hooks/useDragShape.js
@@ -97,7 +97,6 @@ function useDragShape(
 
       let movedTop;
       let movedLeft;
-      let isLocked = false; // eslint-disable-line no-unused-vars
       let isLeftAttached = false;
       let isRightAttached = false;
       let isVerMidAttached = false;
@@ -150,7 +149,6 @@ function useDragShape(
 
         if (Math.abs(currentLeft - nearestPossibleSnapAtX) < GRAVITY) {
           shape.style.left = nearestPossibleSnapAtX + "px";
-          isLocked = true;
           isLeftAttached = true;
           isRightAttached = false;
           isVerMidAttached = false;
@@ -159,7 +157,6 @@ function useDragShape(
           GRAVITY
         ) {
           shape.style.left = nearestPossibleSnapAtX - originalElWidth + "px";
-          isLocked = true;
           isRightAttached = true;
           isLeftAttached = false;
           isVerMidAttached = false;
@@ -169,13 +166,11 @@ function useDragShape(
         ) {
           shape.style.left =
             nearestPossibleSnapAtX - originalElWidth / 2 + "px";
-          isLocked = true;
           isRightAttached = false;
           isLeftAttached = false;
           isVerMidAttached = true;
         } else {
           shape.style.left = currentLeft + "px";
-          isLocked = false;
           isLeftAttached = false;
           isRightAttached = false;
           isVerMidAttached = false;
@@ -183,7 +178,6 @@ function useDragShape(
 
         if (Math.abs(currentTop - nearestPossibleSnapAtY) < GRAVITY) {
           shape.style.top = nearestPossibleSnapAtY + "px";
-          isLocked = true;
           isTopAttached = true;
           isBottomAttached = false;
           isHorMidAttached = false;
@@ -192,7 +186,6 @@ function useDragShape(
           GRAVITY
         ) {
           shape.style.top = nearestPossibleSnapAtY - originalElHeight + "px";
-          isLocked = true;
           isBottomAttached = true;
           isTopAttached = false;
           isHorMidAttached = false;
@@ -202,13 +195,11 @@ function useDragShape(
         ) {
           shape.style.top =
             nearestPossibleSnapAtY - originalElHeight / 2 + "px";
-          isLocked = true;
           isBottomAttached = false;
           isTopAttached = false;
           isHorMidAttached = true;
         } else {
           shape.style.top = currentTop + "px";
-          isLocked = false;
           isTopAttached = false;
           isBottomAttached = false;
           isHorMidAttached = false;


### PR DESCRIPTION
캔버스의 이름을 드래그 하면 주위 캔버스의 `top, bottom, left, right` 축에 스냅이 걸리는 기능을 추가했다. 도형의 스냅 기능과는 달리, 중심 XY 축은 스냅이 걸리지 않도록 했다. 사용자 관점에서 생각 했을 때 그게 맞는 것 같아서 그렇게 했다.