### PR TITLE
JSX 컴파일 관련 패키지 Lazy Load

### DIFF
--- a/src/components/atoms/CompileButton/index.js
+++ b/src/components/atoms/CompileButton/index.js
@@ -7,9 +7,6 @@ import {
 } from "../../../features/utility/utilitySlice";
 import styles from "./CompileButton.module.scss";
 import CompileModal from "../CompileModal";
-import compileHtmlToJsx from "../../../utilities/compileHtmlToJsx";
-import prettifyCode from "../../../utilities/prettifyCode";
-import wait from "../../../utilities/wait";
 
 function CompileButton() {
   const dispatch = useDispatch();
@@ -21,7 +18,12 @@ function CompileButton() {
   const compiler = async () => {
     dispatch(emptySelectedShapeIndexes());
 
-    await wait(0.2);
+    const { default: compileHtmlToJsx } = await import(
+      "../../../utilities/compileHtmlToJsx"
+    );
+    const { default: prettifyCode } = await import(
+      "../../../utilities/prettifyCode"
+    );
 
     const canvasNodeIndex = workingCanvasIndex * 2 + 1;
     const canvasNode =

--- a/src/components/atoms/ImportButton/index.js
+++ b/src/components/atoms/ImportButton/index.js
@@ -10,7 +10,7 @@ import {
 } from "../../../features/utility/utilitySlice";
 import { INVALID_FILE } from "../../../constants/errors";
 import styles from "./ImportButton.module.scss";
-import { workbenchReducerName } from "../../../store/configureStore";
+import { WORKBENCH_REDUCER_NAME } from "../../../store/configureStore";
 
 const ERROR_DURATION = 2000;
 
@@ -31,7 +31,7 @@ function ImportButton() {
         file = JSON.parse(e.target.result);
 
         if (
-          !Object.prototype.hasOwnProperty.call(file, workbenchReducerName) ||
+          !Object.prototype.hasOwnProperty.call(file, WORKBENCH_REDUCER_NAME) ||
           !Object.prototype.hasOwnProperty.call(file, utilitySliceName)
         )
           throw INVALID_FILE;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { ActionCreators } from "redux-undo";
 
 import "./styles.scss";
 import App from "./App";
-import store, { workbenchReducerName } from "./store/configureStore";
+import store, { WORKBENCH_REDUCER_NAME } from "./store/configureStore";
 import "./utilities/defaultEventListeners";
 import LOCAL_STORAGE_KEY from "./constants/localStorage";
 import { loadUtility, utilitySliceName } from "./features/utility/utilitySlice";
@@ -21,7 +21,7 @@ if (lastSavedWork) {
     const data = JSON.parse(lastSavedWork);
 
     if (
-      !Object.prototype.hasOwnProperty.call(data, workbenchReducerName) ||
+      !Object.prototype.hasOwnProperty.call(data, WORKBENCH_REDUCER_NAME) ||
       !Object.prototype.hasOwnProperty.call(data, utilitySliceName)
     )
       throw INVALID_FILE;

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -7,7 +7,6 @@ import utilitySlice from "../features/utility/utilitySlice";
 import { batchGroupBy } from "../utilities/batchActions";
 
 const MAXIMUM_UNDO_COUNT = 100;
-const WORKBENCH_REDUCER_NAME = "workbench";
 
 const workbench = combineReducers({
   globalStyles: globalStylesSlice,
@@ -28,4 +27,4 @@ const store = configureStore({
 
 export default store;
 
-export const workbenchReducerName = WORKBENCH_REDUCER_NAME;
+export const WORKBENCH_REDUCER_NAME = "workbench";


### PR DESCRIPTION
컴파일 관련 라이브러리 (`htmltojsx-too`, `prettier`) 를 설치한 이후로 빌드할 때 마다 asset, entrypoint 사이즈가 너무 크다는 경고가 떴다. 대략 1.2Mib 정도. 그래서 컴파일 버튼을 눌렀을 때 위의 두 패키지를 Lazy Load 하도록 수정했다. 이제 entrypoint 사이즈는 270KiB 정도로 작아졌고, asset 은 합치면 1Mib 정도 되지만 내 생각에 중요한 건 엔트리포인트이기 때문에 만족스럽다.