### PR TITLE
도형 다중 선택시 다른 캔버스 도형도 영향가는 문제 해결

### DIFF
--- a/src/components/atoms/Canvas/index.js
+++ b/src/components/atoms/Canvas/index.js
@@ -39,7 +39,7 @@ function Canvas({ artBoardRef, canvasIndex, ...canvas }) {
 
   useDragCanvas(canvasRef, nameRef, artBoardRef, canvasIndex, !isDoubleClicked);
 
-  useDragMultipleShapes(canvasRef, canvasIndex);
+  useDragMultipleShapes(canvasRef);
 
   const handleInputBlur = () => {
     setIsDoubleClicked(false);

--- a/src/hooks/useDragMultipleShapes.js
+++ b/src/hooks/useDragMultipleShapes.js
@@ -12,6 +12,7 @@ import {
   finishDraggingShape,
   selectCurrentScale,
   selectCurrentTool,
+  selectCurrentWorkingCanvasIndex,
   selectSelectedShapeIndexes,
   startDraggingShape,
 } from "../features/utility/utilitySlice";
@@ -20,11 +21,12 @@ import computeSnapPosition from "../utilities/computeSnapPosition";
 
 const GRAVITY = 5;
 
-function useDragMultipleShapes(canvasRef, canvasIndex) {
+function useDragMultipleShapes(canvasRef) {
   const dispatch = useDispatch();
 
   const canvases = useSelector(selectAllCanvas);
   const selectedShapeIndexes = useSelector(selectSelectedShapeIndexes);
+  const workingCanvasIndex = useSelector(selectCurrentWorkingCanvasIndex);
   const currentTool = useSelector(selectCurrentTool);
   const currentScale = useSelector(selectCurrentScale);
 
@@ -36,10 +38,13 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
     )
       return;
 
-    const canvas = canvasRef.current;
+    const canvasNodeIndex = workingCanvasIndex * 2 + 1;
+    const canvas =
+      document.querySelector("#root").childNodes[1].childNodes[1].firstChild
+        .childNodes[canvasNodeIndex];
 
     const selectionWrapper = computeSelectionBox(
-      canvases[canvasIndex].children,
+      canvases[workingCanvasIndex].children,
       selectedShapeIndexes
     );
 
@@ -72,7 +77,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
       const originalMousePositionLeft = e.clientX;
       const allShapes = e.currentTarget.parentNode.childNodes;
 
-      const shapeList = canvases[canvasIndex].children.slice();
+      const shapeList = canvases[workingCanvasIndex].children.slice();
       const filteredXAxisSnapPoints = [];
       const filteredYAxisSnapPoints = [];
       const selectedShapes = [];
@@ -256,7 +261,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                     nearestPossibleSnapAtY + selectedShapePositions[i].verGap,
                   left:
                     nearestPossibleSnapAtX + selectedShapePositions[i].horGap,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -269,7 +274,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                     originalElHeight,
                   left:
                     nearestPossibleSnapAtX + selectedShapePositions[i].horGap,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -282,7 +287,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                     nearestPossibleSnapAtX +
                     selectedShapePositions[i].horGap -
                     originalElWidth,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -297,7 +302,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                     nearestPossibleSnapAtX +
                     selectedShapePositions[i].horGap -
                     originalElWidth,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -307,7 +312,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                   top: newShapeTop + selectedShapePositions[i].verGap,
                   left:
                     nearestPossibleSnapAtX + selectedShapePositions[i].horGap,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -319,7 +324,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                     nearestPossibleSnapAtX +
                     selectedShapePositions[i].horGap -
                     originalElWidth,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -329,7 +334,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                   top:
                     nearestPossibleSnapAtY + selectedShapePositions[i].verGap,
                   left: newShapeLeft + selectedShapePositions[i].horGap,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -341,7 +346,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                     selectedShapePositions[i].verGap -
                     originalElHeight,
                   left: newShapeLeft + selectedShapePositions[i].horGap,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -350,7 +355,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
                 modifyShape({
                   top: newShapeTop + selectedShapePositions[i].verGap,
                   left: newShapeLeft + selectedShapePositions[i].horGap,
-                  canvasIndex,
+                  canvasIndex: workingCanvasIndex,
                   shapeIndex: selectedShapePositions[i].shapeIndex,
                 })
               );
@@ -377,7 +382,7 @@ function useDragMultipleShapes(canvasRef, canvasIndex) {
       ghostContainer.remove();
     };
   }, [
-    canvasIndex,
+    workingCanvasIndex,
     canvasRef,
     canvases,
     currentScale,


### PR DESCRIPTION
캔버스가 하나 이상일 때, 도형을 다중 선택하면 모든 캔버스의 도형들 위에 투명 Div 가 생기는 것을 확인했다. ArtBoard 컴포넌트에서 Canvas 컴포넌트를 map 돌려서 띄워주고 있는데 다중 선택 훅은 Canvas 내부에서 Canvas 의 인덱스와 Ref 를 인자로 받아서 호출된다. 당연히 모든 캔버스의 도형들이 영향가는 구조였기 때문에 스토어에서 작업중인 캔버스의 인덱스를 받아오는 방식으로 변경했다.